### PR TITLE
Adds missing unit and integration tests for CloudflareFacade.

### DIFF
--- a/CloudflareFacade.php
+++ b/CloudflareFacade.php
@@ -74,13 +74,12 @@ class CloudflareFacade {
 	protected $zone_id;
 
 	/**
-	 * Constructor
+	 * Instantiate the facade.
 	 *
-	 * @since 3.5
-	 * @author Soponar Cristina
+	 * @param Api $api Instance of the Cloudflare API.
 	 */
-	public function __construct() {
-		$this->api = new Api();
+	public function __construct( Api $api ) {
+		$this->api = $api;
 	}
 
 	/**
@@ -97,10 +96,19 @@ class CloudflareFacade {
 	public function set_api_credentials( $email, $api_key, $zone_id ) {
 		$this->api->setEmail( $email );
 		$this->api->setAuthKey( $api_key );
-		$this->api->setCurlOption( CURLOPT_USERAGENT, 'wp-rocket/' . WP_ROCKET_VERSION );
+		$this->api->setCurlOption( CURLOPT_USERAGENT, 'wp-rocket/' . rocket_get_constant( 'WP_ROCKET_VERSION', '3.5' ) );
 
 		$this->zone_id = $zone_id;
 		// Loading with Valid API Credentials.
+		$this->init_api_objects();
+	}
+
+	/**
+	 * Initialize the API's objects, i.e. page rules, cache, settings, and IPs.
+	 *
+	 * @since 3.5
+	 */
+	protected function init_api_objects() {
 		$this->page_rules = new Pagerules( $this->api );
 		$this->cache      = new Cache( $this->api );
 		$this->settings   = new Settings( $this->api );

--- a/Tests/Integration/CloudflareFacade/TestCase.php
+++ b/Tests/Integration/CloudflareFacade/TestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Integration\TestCase as BaseTestCase;
+use function WPMedia\Cloudflare\Tests\Integration\getFactory;
+
+abstract class TestCase extends BaseTestCase {
+	protected static $api;
+	protected static $cf;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$api = getFactory()->getContainer( 'cloudflare_api' );
+		self::$cf  = getFactory()->getContainer( 'cloudflare_facade' );
+	}
+
+	protected function getSetting( $setting ) {
+		$response = self::$api->get( 'zones/' . self::$zone_id . '/settings/' . $setting );
+
+		if ( $response->success ) {
+			return $response->result->value;
+		}
+	}
+}

--- a/Tests/Integration/CloudflareFacade/changeBrowserCacheTtl.php
+++ b/Tests/Integration/CloudflareFacade/changeBrowserCacheTtl.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_browser_cache_ttl
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeBrowserCacheTtl extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->change_browser_cache_ttl( 31536000 );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_browser_cache_ttl( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting browser_cache_ttl', $error->message );
+	}
+
+	public function testShouldChangeBrowserCacheTtlWhenSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$orig = (int) $this->getSetting( 'browser_cache_ttl' );
+		$new  = $orig > 0 ? $orig - 3600 : 3600;
+
+		$response = self::$cf->change_browser_cache_ttl( $new );
+		$this->assertTrue( $response->success );
+		$this->assertSame( $new, $response->result->value );
+		$this->assertNotSame( $orig, $response->result->value );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/changeCacheLevel.php
+++ b/Tests/Integration/CloudflareFacade/changeCacheLevel.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_cache_level
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeCacheLevel extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->change_cache_level( 'aggressive' );
+	}
+
+	public function testShouldFailWhenInvalidLevelGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_cache_level( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting cache_level', $error->message );
+	}
+
+	public function testShouldChangeCacheLevelWhenLevelGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$orig     = $this->getSetting( 'cache_level' );
+		$new      = $this->getNewCacheLevel( $orig );
+		$response = self::$cf->change_cache_level( $new );
+		$this->assertTrue( $response->success );
+		$this->assertSame( $new, $response->result->value );
+		$this->assertNotSame( $orig, $response->result->value );
+	}
+
+	private function getNewCacheLevel( $cache_level ) {
+		foreach ( [ 'aggressive', 'basic', 'simplified' ] as $level ) {
+			if ( $level !== $cache_level ) {
+				return $level;
+			}
+		}
+	}
+}

--- a/Tests/Integration/CloudflareFacade/changeDevelopmentMode.php
+++ b/Tests/Integration/CloudflareFacade/changeDevelopmentMode.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_development_mode
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeDevelopmentMode extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->change_development_mode( 'on' );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_development_mode( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting development_mode', $error->message );
+	}
+
+	public function testShouldSucceedWhenValidSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_development_mode( 'off' );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 'development_mode', $response->result->id );
+		$this->assertSame( 'off', $response->result->value );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/changeMinify.php
+++ b/Tests/Integration/CloudflareFacade/changeMinify.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_minify
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeMinify extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->change_minify(
+			[
+				'css'  => 'on',
+				'html' => 'on',
+				'js'   => 'on',
+			]
+		);
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_minify( [ 'css' => 'invalid' ] );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting minify', $error->message );
+	}
+
+	public function testShouldChangeMinifyWhenSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$orig     = (array) $this->getSetting( 'minify' );
+		$new      = $this->getNewSetting( $orig );
+		$response = self::$cf->change_minify( $new );
+
+		$this->assertTrue( $response->success );
+		$actual = (array) $response->result->value;
+		$this->assertSame( $new, $actual );
+		$this->assertNotSame( $orig, $actual );
+	}
+
+	private function getNewSetting( $orig ) {
+		foreach ( $orig as $key => $value ) {
+			$orig[ $key ] = 'on' === $value ? 'off' : 'on';
+		}
+
+		return $orig;
+	}
+}

--- a/Tests/Integration/CloudflareFacade/changeRocketLoader.php
+++ b/Tests/Integration/CloudflareFacade/changeRocketLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_rocket_loader
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeRocketLoader extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->change_rocket_loader( 'off' );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->change_rocket_loader( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting rocket_loader', $error->message );
+	}
+
+	public function testShouldChangeRocketLoaderWhenSettingGiven() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$orig     = $this->getSetting( 'rocket_loader' );
+		$new      = 'off' == $orig ? 'on' : 'off';
+		$response = self::$cf->change_rocket_loader( $new );
+
+		$this->assertTrue( $response->success );
+		$this->assertSame( $new, $response->result->value );
+		$this->assertNotSame( $orig, $response->result->value );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/getZones.php
+++ b/Tests/Integration/CloudflareFacade/getZones.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::get_zones
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_GetZones extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->get_zones();
+	}
+
+	public function testShouldFailWhenInvalid() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, 'ZONE_ID' );
+
+		$response = self::$cf->get_zones();
+		$this->assertFalse( $response->success );
+		$this->assertCount( 2, $response->errors );
+		$zone_error = $response->errors[0];
+		$this->assertSame( 7003, $zone_error->code );
+		$this->assertSame( 'Could not route to /zones/ZONE_ID, perhaps your object identifier is invalid?', $zone_error->message );
+	}
+
+	public function testShouldSucceedWhenZoneExists() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->get_zones();
+		$this->assertTrue( $response->success );
+		$this->assertSame( self::$zone_id, $response->result->id );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/ips.php
+++ b/Tests/Integration/CloudflareFacade/ips.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::ips
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Ips extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->ips();
+	}
+
+	public function testShouldReturnIps() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, null );
+
+		$response = self::$cf->ips();
+		$this->assertTrue( $response->success );
+		$this->assertContains( '173.245.48.0/20', $response->result->ipv4_cidrs );
+		$this->assertContains( '2400:cb00::/32', $response->result->ipv6_cidrs );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/listPagerules.php
+++ b/Tests/Integration/CloudflareFacade/listPagerules.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::list_pagerules
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ListPagerules extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->list_pagerules();
+	}
+
+	public function testShouldGetPageRulesWhenZoneIdIsSet() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->list_pagerules();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/purge.php
+++ b/Tests/Integration/CloudflareFacade/purge.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::purge
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Purge extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->purge();
+	}
+
+	public function testShouldPurgeCacheWhenZoneIdIsSet() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->purge();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/purgeFiles.php
+++ b/Tests/Integration/CloudflareFacade/purgeFiles.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::purge_files
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_PurgeFiles extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->purge_files( [ '/purge-url' ] );
+	}
+
+	public function testShouldFailWhenUrlInvalid() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->purge_files( ['/invalid/URL'] );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Unable to purge /invalid/URL, which is an invalid URL.', $response->errors[0]->message );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/purgeFiles.php
+++ b/Tests/Integration/CloudflareFacade/purgeFiles.php
@@ -26,4 +26,8 @@ class Test_PurgeFiles extends TestCase {
 		$this->assertFalse( $response->success );
 		$this->assertSame( 'Unable to purge /invalid/URL, which is an invalid URL.', $response->errors[0]->message );
 	}
+
+	public function testShouldSucceedWhenUrlsGiven() {
+		$this->assertTrue( true );
+	}
 }

--- a/Tests/Integration/CloudflareFacade/setApiCredentials.php
+++ b/Tests/Integration/CloudflareFacade/setApiCredentials.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+use Cloudflare\IPs;
+use Cloudflare\Zone\Cache;
+use Cloudflare\Zone\Pagerules;
+use Cloudflare\Zone\Settings;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::set_api_credentials
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_SetApiCredentials extends TestCase {
+	private static $version;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$version = rocket_get_constant( 'WP_ROCKET_VERSION', '3.5' );
+	}
+
+	public function testShouldSetEmail() {
+		self::$cf->set_api_credentials( null, null, null );
+		$this->assertNull( self::$api->email );
+
+		self::$cf->set_api_credentials( 'test@example.com', null, null );
+		$this->assertSame( 'test@example.com', self::$api->email );
+	}
+
+	public function testShouldSetApiKey() {
+		self::$cf->set_api_credentials( null, null, null );
+		$this->assertNull( self::$api->auth_key );
+
+		self::$cf->set_api_credentials( null, 'someAuthKey', null );
+		$this->assertSame( 'someAuthKey', self::$api->auth_key );
+	}
+
+	public function testShouldSetCurlOption() {
+		self::$api->curl_options = null;
+		self::$cf->set_api_credentials( 'test@example.com', 'someAuthKey', 'zone1' );
+		$this->assertArrayHasKey( CURLOPT_USERAGENT, self::$api->curl_options );
+		$this->assertSame( 'wp-rocket/' . self::$version, self::$api->curl_options[ CURLOPT_USERAGENT ] );
+	}
+
+	public function testShouldSetPageRules() {
+		self::$cf->set_api_credentials( 'test@example.com', 'someAuthKey', 'zone1' );
+		$page_rules = $this->get_reflective_property( 'page_rules', self::$cf );
+		$this->assertInstanceOf( Pagerules::class, $page_rules->getValue( self::$cf ) );
+	}
+
+	public function testShouldSetCache() {
+		self::$cf->set_api_credentials( 'test@example.com', 'someAuthKey', 'zone1' );
+		$cache = $this->get_reflective_property( 'cache', self::$cf );
+		$this->assertInstanceOf( Cache::class, $cache->getValue( self::$cf ) );
+	}
+
+	public function testShouldSetSettings() {
+		self::$cf->set_api_credentials( 'test@example.com', 'someAuthKey', 'zone1' );
+		$settings = $this->get_reflective_property( 'settings', self::$cf );
+		$this->assertInstanceOf( Settings::class, $settings->getValue( self::$cf ) );
+	}
+
+	public function testShouldSetIps() {
+		self::$cf->set_api_credentials( 'test@example.com', 'someAuthKey', 'zone1' );
+		$ips = $this->get_reflective_property( 'ips', self::$cf );
+		$this->assertInstanceOf( IPs::class, $ips->getValue( self::$cf ) );
+	}
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$api->get( 'test' );
+	}
+
+	public function testShouldGetResponseWhenCredentialsAreValid() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, null );
+
+		$response = self::$api->get( 'test' );
+		$this->assertSame( 'get', $response->method );
+	}
+}

--- a/Tests/Integration/CloudflareFacade/settings.php
+++ b/Tests/Integration/CloudflareFacade/settings.php
@@ -25,9 +25,6 @@ class Test_Settings extends TestCase {
 		$response = self::$cf->settings();
 		$this->assertTrue( $response->success );
 		$this->assertEmpty( $response->errors );
-		$settings = array_column( $response->result, 'id' );
-
-		$this->assertContains( 'browser_cache_ttl', $settings );
-		$this->assertContains( 'cache_level', $settings );
+		$this->assertGreaterThan( 10, $response->result );
 	}
 }

--- a/Tests/Integration/CloudflareFacade/settings.php
+++ b/Tests/Integration/CloudflareFacade/settings.php
@@ -25,6 +25,6 @@ class Test_Settings extends TestCase {
 		$response = self::$cf->settings();
 		$this->assertTrue( $response->success );
 		$this->assertEmpty( $response->errors );
-		$this->assertGreaterThan( 10, $response->result );
+		$this->assertGreaterThan( 4, $response->result );
 	}
 }

--- a/Tests/Integration/CloudflareFacade/settings.php
+++ b/Tests/Integration/CloudflareFacade/settings.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareFacade;
+
+use Cloudflare\Exception\AuthenticationException;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::settings
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Settings extends TestCase {
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		self::$cf->set_api_credentials( null, null, null );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		self::$cf->settings();
+	}
+
+	public function testShouldReturnSettingsWhenZoneIdIsSet() {
+		self::$cf->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+
+		$response = self::$cf->settings();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
+		$settings = array_column( $response->result, 'id' );
+
+		$this->assertContains( 'browser_cache_ttl', $settings );
+		$this->assertContains( 'cache_level', $settings );
+	}
+}

--- a/Tests/Integration/CloudflareSubscriber/deactivateDevMode.php
+++ b/Tests/Integration/CloudflareSubscriber/deactivateDevMode.php
@@ -10,6 +10,13 @@ use function WPMedia\Cloudflare\Tests\Integration\getFactory;
  * @group  Subscriber
  */
 class Test_DeactivateDevMode extends TestCase {
+	private static $options;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$options = getFactory()->getContainer( 'options' );
+	}
 
 	/**
 	 * Test should not deactivate cloudflare dev mode when cloudflare addon is off.
@@ -20,8 +27,7 @@ class Test_DeactivateDevMode extends TestCase {
 			'cloudflare_devmode' => 'on',
 		];
 		update_option( 'wp_rocket_settings', $data );
-		$options = getFactory()->getContainer( 'options' );
-		$options->set_values( $data );
+		self::$options->set_values( $data );
 
 		do_action( 'rocket_cron_deactivate_cloudflare_devmode' );
 
@@ -38,12 +44,11 @@ class Test_DeactivateDevMode extends TestCase {
 			'cloudflare_devmode' => 'on',
 		];
 		update_option( 'wp_rocket_settings', $data );
-		$options = getFactory()->getContainer( 'options' );
-		$options->set_values( $data );
+		self::$options->set_values( $data );
 
 		do_action( 'rocket_cron_deactivate_cloudflare_devmode' );
 
-		$this->assertSame( 'off', $options->get( 'cloudflare_devmode' ) );
+		$this->assertSame( 'off', self::$options->get( 'cloudflare_devmode' ) );
 		$settings = get_option( 'wp_rocket_settings' );
 		$this->assertSame( 'off', $settings['cloudflare_devmode'] );
 	}

--- a/Tests/Integration/Factory.php
+++ b/Tests/Integration/Factory.php
@@ -2,6 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Integration;
 
+use Cloudflare\Api;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Event_Manager;
@@ -48,7 +49,8 @@ class Factory {
 		$this->container['options']           = new Options_Data(
 			$this->container['options_api']->get( 'settings', [] )
 		);
-		$this->container['cloudflare_facade'] = new CloudflareFacade();
+		$this->container['cloudflare_api']    = new Api();
+		$this->container['cloudflare_facade'] = new CloudflareFacade( $this->container['cloudflare_api'] );
 		$this->container['cloudflare']        = new Cloudflare( $this->container['options'], $this->container['cloudflare_facade'] );
 
 		$this->container['cloudflare_subscriber'] = new CloudflareSubscriber(

--- a/Tests/Unit/CloudflareFacade/TestCase.php
+++ b/Tests/Unit/CloudflareFacade/TestCase.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use InvalidArgumentException;
+use Mockery;
+use WPMedia\Cloudflare\Tests\Unit\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {
+	protected $deps = [
+		'ips'        => 'Cloudflare\IPs',
+		'cache'      => 'Cloudflare\Zone\Cache',
+		'page_rules' => 'Cloudflare\Zone\Pagerules',
+		'settings'   => 'Cloudflare\Zone\Settings',
+	];
+
+	protected function getMocks( $setApiExpects = true ) {
+		$api = $this->getApi( $setApiExpects );
+
+		return [ $api, $this->getFacade( $api ) ];
+	}
+
+	protected function getMocksWithDep( $property = null, $setApiExpects = true ) {
+		$api = $this->getApi( $setApiExpects );
+		$cf  = $this->getFacade( $api );
+
+		if ( ! array_key_exists( $property, $this->deps ) ) {
+			throw new InvalidArgumentException( 'No dependency given for test.' );
+		}
+
+		$dep = Mockery::mock( $this->deps[ $property ], [ $api ] );
+		$this->set_reflective_property( $dep, $property, $cf );
+
+		return [ $cf, $dep ];
+	}
+
+	private function getApi( $setApiExpects = true ) {
+		if ( $setApiExpects ) {
+			return Mockery::mock( Api::class, [
+				'setEmail'      => null,
+				'setAuthKey'    => null,
+				'setCurlOption' => null,
+			] );
+		}
+
+		Return Mockery::mock( Api::class );
+	}
+
+	private function getCache( $api, $cf ) {
+
+	}
+}

--- a/Tests/Unit/CloudflareFacade/changeBrowserCacheTtl.php
+++ b/Tests/Unit/CloudflareFacade/changeBrowserCacheTtl.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use Cloudflare\Exception\AuthenticationException;
+use Cloudflare\Zone\Settings;
+use Mockery;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_browser_cache_ttl
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeBrowserCacheTtl extends TestCase {
+
+	protected function getFacade( $api_mock ) {
+		$mock = Mockery::mock( 'WPMedia\Cloudflare\CloudflareFacade[init_api_objects]', [ $api_mock ] )->shouldAllowMockingProtectedMethods();
+		$mock->shouldReceive( 'init_api_objects' )->andReturnNull();
+
+		return $mock;
+	}
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		$api      = Mockery::mock( Api::class );
+		$cf       = $this->getFacade( $api );
+		$settings = Mockery::mock( Settings::class, [ $api ] );
+		$this->set_reflective_property( $settings, 'settings', $cf );
+
+		$settings->shouldReceive( 'change_browser_cache_ttl' )
+		         ->once()
+		         ->with( null, 31536000 )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->change_browser_cache_ttl( 31536000 );
+	}
+
+	public function testShouldChangeBrowserCacheTtlWhenTTLGiven() {
+		$api      = Mockery::mock( Api::class, [
+			'setEmail'      => null,
+			'setAuthKey'    => null,
+			'setCurlOption' => null,
+		] );
+		$cf       = $this->getFacade( $api );
+		$settings = Mockery::mock( Settings::class, [ $api ] );
+		$this->set_reflective_property( $settings, 'settings', $cf );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_browser_cache_ttl' )
+		         ->once()
+		         ->with( 'zone1234', 31536000 )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'   => (object) [
+					         'value' => 31536000,
+				         ],
+				         'success'  => true,
+				         'errors'   => [],
+				         'messages' => [],
+			         ];
+		         } );
+
+		$response = $cf->change_browser_cache_ttl( 31536000 );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 31536000, $response->result->value );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/changeCacheLevel.php
+++ b/Tests/Unit/CloudflareFacade/changeCacheLevel.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use Cloudflare\Exception\AuthenticationException;
+use Cloudflare\Zone\Settings;
+use Mockery;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_cache_level
+ * @group  Facade
+ */
+class Test_ChangeCacheLevel extends TestCase {
+
+	private function getMocks( $setApiExpects = true ) {
+		if ( $setApiExpects ) {
+			$api = Mockery::mock( Api::class, [
+				'setEmail'      => null,
+				'setAuthKey'    => null,
+				'setCurlOption' => null,
+			] );
+		} else {
+			$api = Mockery::mock( Api::class );
+		}
+
+		$cf       = $this->getFacade( $api );
+		$settings = Mockery::mock( Settings::class, [ $api ] );
+		$this->set_reflective_property( $settings, 'settings', $cf );
+
+		return [ $cf, $settings ];
+	}
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $settings ) = $this->getMocks( false );
+
+		$settings->shouldReceive( 'change_cache_level' )
+		         ->once()
+		         ->with( null, 'aggressive' )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->change_cache_level( 'aggressive' );
+	}
+
+	public function testShouldReturnIps() {
+		list( $cf, $settings ) = $this->getMocks();
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_cache_level' )
+		         ->once()
+		         ->with( 'zone1234', 'aggressive' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'   => (object) [
+					         'value' => 'aggressive',
+				         ],
+				         'success'  => true,
+				         'errors'   => [],
+				         'messages' => [],
+			         ];
+		         } );
+
+		$response = $cf->change_cache_level( 'aggressive' );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 'aggressive', $response->result->value );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/changeDevelopmentMode.php
+++ b/Tests/Unit/CloudflareFacade/changeDevelopmentMode.php
@@ -2,11 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use Cloudflare\Api;
 use Cloudflare\Exception\AuthenticationException;
-use Cloudflare\Zone\Settings;
-use Mockery;
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::change_development_mode
@@ -15,26 +11,8 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_ChangeDevelopmentMode extends TestCase {
 
-	private function getMocks( $setApiExpects = true ) {
-		if ( $setApiExpects ) {
-			$api = Mockery::mock( Api::class, [
-				'setEmail'      => null,
-				'setAuthKey'    => null,
-				'setCurlOption' => null,
-			] );
-		} else {
-			$api = Mockery::mock( Api::class );
-		}
-
-		$cf       = $this->getFacade( $api );
-		$settings = Mockery::mock( Settings::class, [ $api ] );
-		$this->set_reflective_property( $settings, 'settings', $cf );
-
-		return [ $cf, $settings ];
-	}
-
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		list( $cf, $settings ) = $this->getMocks( false );
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings', false );
 
 		$settings->shouldReceive( 'change_development_mode' )
 		         ->once()
@@ -49,7 +27,7 @@ class Test_ChangeDevelopmentMode extends TestCase {
 	}
 
 	public function testShouldFailWhenInvalidSettingGiven() {
-		list( $cf, $settings ) = $this->getMocks();
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
 
 		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
 
@@ -58,14 +36,13 @@ class Test_ChangeDevelopmentMode extends TestCase {
 		         ->with( 'zone1234', 'invalid' )
 		         ->andReturnUsing( function() {
 			         return (object) [
-				         'result'   => null,
-				         'success'  => false,
-				         'errors'   => [
+				         'result'  => null,
+				         'success' => false,
+				         'errors'  => [
 					         (object) [
 						         'message' => 'Invalid value for zone setting development_mode',
 					         ],
 				         ],
-				         'messages' => [],
 			         ];
 		         } );
 
@@ -76,7 +53,7 @@ class Test_ChangeDevelopmentMode extends TestCase {
 	}
 
 	public function testShouldSucceedWhenValidSettingGiven() {
-		list( $cf, $settings ) = $this->getMocks();
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
 
 		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
 
@@ -85,13 +62,12 @@ class Test_ChangeDevelopmentMode extends TestCase {
 		         ->with( 'zone1234', 'invalid' )
 		         ->andReturnUsing( function() {
 			         return (object) [
-				         'result'   => (object) [
+				         'result'  => (object) [
 					         'id'    => 'development_mode',
 					         'value' => 'off',
 				         ],
-				         'success'  => true,
-				         'errors'   => [],
-				         'messages' => [],
+				         'success' => true,
+				         'errors'  => [],
 			         ];
 		         } );
 

--- a/Tests/Unit/CloudflareFacade/changeDevelopmentMode.php
+++ b/Tests/Unit/CloudflareFacade/changeDevelopmentMode.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use Cloudflare\Exception\AuthenticationException;
+use Cloudflare\Zone\Settings;
+use Mockery;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_development_mode
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeDevelopmentMode extends TestCase {
+
+	private function getMocks( $setApiExpects = true ) {
+		if ( $setApiExpects ) {
+			$api = Mockery::mock( Api::class, [
+				'setEmail'      => null,
+				'setAuthKey'    => null,
+				'setCurlOption' => null,
+			] );
+		} else {
+			$api = Mockery::mock( Api::class );
+		}
+
+		$cf       = $this->getFacade( $api );
+		$settings = Mockery::mock( Settings::class, [ $api ] );
+		$this->set_reflective_property( $settings, 'settings', $cf );
+
+		return [ $cf, $settings ];
+	}
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $settings ) = $this->getMocks( false );
+
+		$settings->shouldReceive( 'change_development_mode' )
+		         ->once()
+		         ->with( null, 'on' )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->change_development_mode( 'on' );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		list( $cf, $settings ) = $this->getMocks();
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_development_mode' )
+		         ->once()
+		         ->with( 'zone1234', 'invalid' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'   => null,
+				         'success'  => false,
+				         'errors'   => [
+					         (object) [
+						         'message' => 'Invalid value for zone setting development_mode',
+					         ],
+				         ],
+				         'messages' => [],
+			         ];
+		         } );
+
+		$response = $cf->change_development_mode( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting development_mode', $error->message );
+	}
+
+	public function testShouldSucceedWhenValidSettingGiven() {
+		list( $cf, $settings ) = $this->getMocks();
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_development_mode' )
+		         ->once()
+		         ->with( 'zone1234', 'invalid' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'   => (object) [
+					         'id'    => 'development_mode',
+					         'value' => 'off',
+				         ],
+				         'success'  => true,
+				         'errors'   => [],
+				         'messages' => [],
+			         ];
+		         } );
+
+		$response = $cf->change_development_mode( 'invalid' );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 'development_mode', $response->result->id );
+		$this->assertSame( 'off', $response->result->value );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/changeMinify.php
+++ b/Tests/Unit/CloudflareFacade/changeMinify.php
@@ -2,7 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
+use Cloudflare\Exception\AuthenticationException;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::change_minify
@@ -10,8 +10,73 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  * @group  CloudflareFacade
  */
 class Test_ChangeMinify extends TestCase {
+	protected $newSetting = [
+		'css'  => 'on',
+		'html' => 'on',
+		'js'   => 'on',
+	];
 
-	public function testShouldChangeMinifyWhenZoneIdIsSetAndSettingsGiven() {
-		$this->assertTrue( true );
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings', false );
+
+		$settings->shouldReceive( 'change_minify' )
+		         ->once()
+		         ->with( null, $this->newSetting )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->change_minify( $this->newSetting );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_minify' )
+		         ->once()
+		         ->with( 'zone1234', [ 'css' => 'invalid' ] )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'  => [],
+				         'success' => false,
+				         'errors'  => [
+					         (object) [
+						         'message' => 'Invalid value for zone setting minify',
+					         ],
+				         ],
+			         ];
+		         } );
+
+		$response = $cf->change_minify( [ 'css' => 'invalid' ] );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting minify', $error->message );
+	}
+
+	public function testShouldChangeMinifyWhenSettingGiven() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_minify' )
+		         ->once()
+		         ->with( 'zone1234', $this->newSetting )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'  => (object) [
+					         'value' => $this->newSetting,
+				         ],
+				         'success' => true,
+				         'errors'  => [],
+			         ];
+		         } );
+
+		$response = $cf->change_minify( $this->newSetting );
+		$this->assertTrue( $response->success );
+		$this->assertSame( $this->newSetting, $response->result->value );
 	}
 }

--- a/Tests/Unit/CloudflareFacade/changeMinify.php
+++ b/Tests/Unit/CloudflareFacade/changeMinify.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_minify
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeMinify extends TestCase {
+
+	public function testShouldChangeMinifyWhenZoneIdIsSetAndSettingsGiven() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/changeRocketLoader.php
+++ b/Tests/Unit/CloudflareFacade/changeRocketLoader.php
@@ -2,7 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
+use Cloudflare\Exception\AuthenticationException;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::change_rocket_loader
@@ -11,7 +11,67 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_ChangeRocketLoader extends TestCase {
 
-	public function testShouldChangeRocketLoaderlWhenZoneIdIsSetAndModeGiven() {
-		$this->assertTrue( true );
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings', false );
+
+		$settings->shouldReceive( 'change_rocket_loader' )
+		         ->once()
+		         ->with( null, 'off' )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->change_rocket_loader( 'off' );
+	}
+
+	public function testShouldFailWhenInvalidSettingGiven() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_rocket_loader' )
+		         ->once()
+		         ->with( 'zone1234', 'invalid' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'  => [],
+				         'success' => false,
+				         'errors'  => [
+					         (object) [
+						         'message' => 'Invalid value for zone setting rocket_loader',
+					         ],
+				         ],
+			         ];
+		         } );
+
+		$response = $cf->change_rocket_loader( 'invalid' );
+		$this->assertFalse( $response->success );
+		$error = $response->errors[0];
+		$this->assertSame( 'Invalid value for zone setting rocket_loader', $error->message );
+	}
+
+	public function testShouldChangeRocketLoaderWhenSettingGiven() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'change_rocket_loader' )
+		    ->once()
+			->with( 'zone1234', 'on' )
+			->andReturnUsing( function() {
+				return (object) [
+					'result'  => (object) [
+						'value' => 'on',
+					],
+					'success' => true,
+					'errors'   => [],
+				];
+			} );
+
+		$response = $cf->change_rocket_loader( 'on' );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 'on', $response->result->value );
 	}
 }

--- a/Tests/Unit/CloudflareFacade/changeRocketLoader.php
+++ b/Tests/Unit/CloudflareFacade/changeRocketLoader.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::change_rocket_loader
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ChangeRocketLoader extends TestCase {
+
+	public function testShouldChangeRocketLoaderlWhenZoneIdIsSetAndModeGiven() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/getZones.php
+++ b/Tests/Unit/CloudflareFacade/getZones.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use Cloudflare\Exception\AuthenticationException;
+use Mockery;
+use WPMedia\Cloudflare\CloudflareFacade;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::get_zones
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_GetZones extends TestCase {
+
+	public function testShouldFailWhenZoneIdInvalid() {
+		$api_mock = Mockery::mock( Api::class );
+		$cf       = new CloudflareFacade( $api_mock );
+
+		$api_mock->shouldReceive( 'get' )
+		         ->once()
+		         ->with( 'zones/' )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->get_zones();
+	}
+
+	public function testShouldSucceedWhenZoneExists() {
+		$api_mock = Mockery::mock( Api::class );
+		$cf       = new CloudflareFacade( $api_mock );
+
+		$api_mock->shouldReceive( 'get' )
+		         ->once()
+		         ->with( 'zones/' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'   => (object) [],
+				         'success'  => true,
+				         'errors'   => [],
+				         'messages' => [],
+			         ];
+		         } );
+		$response = $cf->get_zones();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/ips.php
+++ b/Tests/Unit/CloudflareFacade/ips.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Cloudflare\Api;
+use Cloudflare\Exception\AuthenticationException;
+use Cloudflare\IPs;
+use Mockery;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::ips
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Ips extends TestCase {
+
+	private function getMocks( $setApiExpects = true ) {
+		if ( $setApiExpects ) {
+			$api = Mockery::mock( Api::class, [
+				'setEmail'      => null,
+				'setAuthKey'    => null,
+				'setCurlOption' => null,
+			] );
+		} else {
+			$api = Mockery::mock( Api::class );
+		}
+
+		$cf       = $this->getFacade( $api );
+		$ips = Mockery::mock( IPs::class, [ $api ] );
+		$this->set_reflective_property( $ips, 'ips', $cf );
+
+		return [ $cf, $ips ];
+	}
+
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $ips ) = $this->getMocks( false );
+
+		$ips->shouldReceive( 'ips' )
+		    ->once()
+		    ->andReturnUsing( function() {
+			    throw new AuthenticationException( 'Authentication information must be provided' );
+		    } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->ips();
+	}
+
+	public function testShouldReturnIps() {
+		list( $cf, $ips ) = $this->getMocks();
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$ips->shouldReceive( 'ips' )
+		    ->once()
+		    ->andReturnUsing( function() {
+			    return (object) [
+				    'result'   => (object) [
+					    'ipv4_cidrs' => [ '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22' ],
+					    'ipv6_cidrs' => [ '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32' ],
+				    ],
+				    'success'  => true,
+				    'errors'   => [],
+				    'messages' => [],
+			    ];
+		    } );
+
+		$response = $cf->ips();
+		$this->assertTrue( $response->success );
+		$this->assertContains( '173.245.48.0/20', $response->result->ipv4_cidrs );
+		$this->assertContains( '2400:cb00::/32', $response->result->ipv6_cidrs );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/ips.php
+++ b/Tests/Unit/CloudflareFacade/ips.php
@@ -2,11 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use Cloudflare\Api;
 use Cloudflare\Exception\AuthenticationException;
-use Cloudflare\IPs;
-use Mockery;
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::ips
@@ -15,26 +11,8 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_Ips extends TestCase {
 
-	private function getMocks( $setApiExpects = true ) {
-		if ( $setApiExpects ) {
-			$api = Mockery::mock( Api::class, [
-				'setEmail'      => null,
-				'setAuthKey'    => null,
-				'setCurlOption' => null,
-			] );
-		} else {
-			$api = Mockery::mock( Api::class );
-		}
-
-		$cf       = $this->getFacade( $api );
-		$ips = Mockery::mock( IPs::class, [ $api ] );
-		$this->set_reflective_property( $ips, 'ips', $cf );
-
-		return [ $cf, $ips ];
-	}
-
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		list( $cf, $ips ) = $this->getMocks( false );
+		list( $cf, $ips ) = $this->getMocksWithDep( 'ips', false );
 
 		$ips->shouldReceive( 'ips' )
 		    ->once()
@@ -48,7 +26,7 @@ class Test_Ips extends TestCase {
 	}
 
 	public function testShouldReturnIps() {
-		list( $cf, $ips ) = $this->getMocks();
+		list( $cf, $ips ) = $this->getMocksWithDep( 'ips' );
 
 		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
 
@@ -62,7 +40,6 @@ class Test_Ips extends TestCase {
 				    ],
 				    'success'  => true,
 				    'errors'   => [],
-				    'messages' => [],
 			    ];
 		    } );
 

--- a/Tests/Unit/CloudflareFacade/listPagerules.php
+++ b/Tests/Unit/CloudflareFacade/listPagerules.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::list_pagerules
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_ListPagerules extends TestCase {
+
+	public function testShouldGetPageRulesWhenZoneIdIsSet() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/purge.php
+++ b/Tests/Unit/CloudflareFacade/purge.php
@@ -2,7 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
+use Cloudflare\Exception\AuthenticationException;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::purge
@@ -11,7 +11,39 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_Purge extends TestCase {
 
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $cache ) = $this->getMocksWithDep( 'cache', false );
+
+		$cache->shouldReceive( 'purge' )
+		          ->once()
+		          ->with( null, true )
+		          ->andReturnUsing( function() {
+			          throw new AuthenticationException( 'Authentication information must be provided' );
+		          } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->purge();
+	}
+
 	public function testShouldPurgeCacheWhenZoneIdIsSet() {
-		$this->assertTrue( true );
+		list( $cf, $cache ) = $this->getMocksWithDep( 'cache' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$cache->shouldReceive( 'purge' )
+		          ->once()
+		          ->with( 'zone1234', true )
+		          ->andReturnUsing( function() {
+			          return (object) [
+				          'result'  => [],
+				          'success' => true,
+				          'errors'  => [],
+			          ];
+		          } );
+
+		$response = $cf->purge();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
 	}
 }

--- a/Tests/Unit/CloudflareFacade/purge.php
+++ b/Tests/Unit/CloudflareFacade/purge.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::purge
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Purge extends TestCase {
+
+	public function testShouldPurgeCacheWhenZoneIdIsSet() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/purgeFiles.php
+++ b/Tests/Unit/CloudflareFacade/purgeFiles.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::purge_files
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_PurgeFiles extends TestCase {
+
+	public function testShouldPurgeFilesWhenZoneIdIsSetAndUrlsGiven() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/purgeFiles.php
+++ b/Tests/Unit/CloudflareFacade/purgeFiles.php
@@ -2,7 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
+use Cloudflare\Exception\AuthenticationException;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::purge_files
@@ -11,7 +11,64 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_PurgeFiles extends TestCase {
 
-	public function testShouldPurgeFilesWhenZoneIdIsSetAndUrlsGiven() {
-		$this->assertTrue( true );
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $cache ) = $this->getMocksWithDep( 'cache', false );
+
+		$cache->shouldReceive( 'purge_files' )
+		      ->once()
+		      ->with( null, [ '/purge-url' ] )
+		      ->andReturnUsing( function() {
+			      throw new AuthenticationException( 'Authentication information must be provided' );
+		      } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->purge_files( [ '/purge-url' ] );
+	}
+
+	public function testShouldFailWhenUrlInvalid() {
+		list( $cf, $cache ) = $this->getMocksWithDep( 'cache' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$cache->shouldReceive( 'purge_files' )
+		      ->once()
+		      ->with( 'zone1234', [ '/invalid/URL' ] )
+		      ->andReturnUsing( function() {
+			      return (object) [
+				      'result'  => [],
+				      'success' => false,
+				      'errors'  => [
+					      (object) [
+						      'message' => 'Unable to purge /invalid/URL, which is an invalid URL.',
+					      ],
+				      ],
+			      ];
+		      } );
+
+		$response = $cf->purge_files( [ '/invalid/URL' ] );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Unable to purge /invalid/URL, which is an invalid URL.', $response->errors[0]->message );
+	}
+
+	public function testShouldSucceedWhenUrlsGiven() {
+		list( $cf, $cache ) = $this->getMocksWithDep( 'cache' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$cache->shouldReceive( 'purge_files' )
+		      ->once()
+		      ->with( 'zone1234', [ '/about', '/contact' ] )
+		      ->andReturnUsing( function() {
+			      return (object) [
+				      'result'  => [],
+				      'success' => true,
+				      'errors'  => [],
+			      ];
+		      } );
+
+		$response = $cf->purge_files( [ '/about', '/contact' ] );
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
 	}
 }

--- a/Tests/Unit/CloudflareFacade/setApiCredentials.php
+++ b/Tests/Unit/CloudflareFacade/setApiCredentials.php
@@ -17,13 +17,13 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
 class Test_SetApiCredentials extends TestCase {
 
 	private function getMocks() {
-			$api = Mockery::mock( Api::class, [
-				'setEmail'      => null,
-				'setAuthKey'    => null,
-				'setCurlOption' => null,
-			] );
+		$api = Mockery::mock( Api::class, [
+			'setEmail'      => null,
+			'setAuthKey'    => null,
+			'setCurlOption' => null,
+		] );
 
-		$cf       = $this->getFacade( $api );
+		$cf = $this->getFacade( $api );
 
 		return [ $cf, $api ];
 	}

--- a/Tests/Unit/CloudflareFacade/setApiCredentials.php
+++ b/Tests/Unit/CloudflareFacade/setApiCredentials.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use Brain\Monkey\Functions;
+use Cloudflare\Api;
+use Mockery;
+use WPMedia\Cloudflare\CloudflareFacade;
+use WPMedia\Cloudflare\Cloudflare\Imagify_Data;
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::set_api_credentials
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_SetApiCredentials extends TestCase {
+
+	private function getMocks() {
+			$api = Mockery::mock( Api::class, [
+				'setEmail'      => null,
+				'setAuthKey'    => null,
+				'setCurlOption' => null,
+			] );
+
+		$cf       = $this->getFacade( $api );
+
+		return [ $cf, $api ];
+	}
+
+	/**
+	 * Test should set the email on the API.
+	 */
+	public function testShouldSetEmail() {
+		list( $cf, $api ) = $this->getMocks();
+
+		$api->shouldReceive( 'setEmail' )->with( null );
+		$cf->set_api_credentials( null, null, null );
+
+		$api->shouldReceive( 'setEmail' )->with( 'test@example.com' );
+		$cf->set_api_credentials( 'test@example.com', null, null );
+	}
+
+	/**
+	 * Test should set the API key on the API.
+	 */
+	public function testShouldSetApiKeyWhenGiven() {
+		list( $cf, $api ) = $this->getMocks();
+
+		$api->shouldReceive( 'setAuthKey' )->with( null );
+		$cf->set_api_credentials( null, null, null );
+
+		$api->shouldReceive( 'setAuthKey' )->with( 'API_KEY' );
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', null );
+	}
+
+	/**
+	 * Test should set the curl option with the current version Rocket.
+	 */
+	public function testShouldSetCurlOptionWithCurrentVersionOfRocket() {
+		list( $cf, $api ) = $this->getMocks();
+
+		$api->shouldReceive( 'setCurlOption' )
+		    ->once()
+		    ->with( CURLOPT_USERAGENT, 'wp-rocket/3.5' );
+
+		$cf->set_api_credentials( null, null, null );
+	}
+
+	/**
+	 * Test should set the API key on the API.
+	 */
+	public function testShouldSetZoneId() {
+		list( $cf, $api ) = $this->getMocks();
+		$zone_id = $this->get_reflective_property( 'zone_id', $cf );
+
+		$cf->set_api_credentials( null, null, 'zone1' );
+		$this->assertSame( 'zone1', $zone_id->getValue( $cf ) );
+
+		$cf->set_api_credentials( 'test@example.com', '', 'zone10' );
+		$this->assertSame( 'zone10', $zone_id->getValue( $cf ) );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+		$this->assertSame( 'zone1234', $zone_id->getValue( $cf ) );
+	}
+}

--- a/Tests/Unit/CloudflareFacade/setApiCredentials.php
+++ b/Tests/Unit/CloudflareFacade/setApiCredentials.php
@@ -2,13 +2,6 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use Brain\Monkey\Functions;
-use Cloudflare\Api;
-use Mockery;
-use WPMedia\Cloudflare\CloudflareFacade;
-use WPMedia\Cloudflare\Cloudflare\Imagify_Data;
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
-
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::set_api_credentials
  * @group  Cloudflare
@@ -16,23 +9,11 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_SetApiCredentials extends TestCase {
 
-	private function getMocks() {
-		$api = Mockery::mock( Api::class, [
-			'setEmail'      => null,
-			'setAuthKey'    => null,
-			'setCurlOption' => null,
-		] );
-
-		$cf = $this->getFacade( $api );
-
-		return [ $cf, $api ];
-	}
-
 	/**
 	 * Test should set the email on the API.
 	 */
 	public function testShouldSetEmail() {
-		list( $cf, $api ) = $this->getMocks();
+		list( $api, $cf ) = $this->getMocks();
 
 		$api->shouldReceive( 'setEmail' )->with( null );
 		$cf->set_api_credentials( null, null, null );
@@ -45,7 +26,7 @@ class Test_SetApiCredentials extends TestCase {
 	 * Test should set the API key on the API.
 	 */
 	public function testShouldSetApiKeyWhenGiven() {
-		list( $cf, $api ) = $this->getMocks();
+		list( $api, $cf ) = $this->getMocks();
 
 		$api->shouldReceive( 'setAuthKey' )->with( null );
 		$cf->set_api_credentials( null, null, null );
@@ -58,7 +39,7 @@ class Test_SetApiCredentials extends TestCase {
 	 * Test should set the curl option with the current version Rocket.
 	 */
 	public function testShouldSetCurlOptionWithCurrentVersionOfRocket() {
-		list( $cf, $api ) = $this->getMocks();
+		list( $api, $cf ) = $this->getMocks();
 
 		$api->shouldReceive( 'setCurlOption' )
 		    ->once()
@@ -71,7 +52,7 @@ class Test_SetApiCredentials extends TestCase {
 	 * Test should set the API key on the API.
 	 */
 	public function testShouldSetZoneId() {
-		list( $cf, $api ) = $this->getMocks();
+		list( $api, $cf ) = $this->getMocks();
 		$zone_id = $this->get_reflective_property( 'zone_id', $cf );
 
 		$cf->set_api_credentials( null, null, 'zone1' );

--- a/Tests/Unit/CloudflareFacade/settings.php
+++ b/Tests/Unit/CloudflareFacade/settings.php
@@ -2,7 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
 
-use WPMedia\Cloudflare\Tests\Unit\TestCase;
+use Cloudflare\Exception\AuthenticationException;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareFacade::settings
@@ -11,7 +11,47 @@ use WPMedia\Cloudflare\Tests\Unit\TestCase;
  */
 class Test_Settings extends TestCase {
 
+	public function testShouldThrowErrorWhenInvalidCredentials() {
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings', false );
+
+		$settings->shouldReceive( 'settings' )
+		         ->once()
+		         ->with( null )
+		         ->andReturnUsing( function() {
+			         throw new AuthenticationException( 'Authentication information must be provided' );
+		         } );
+
+		$this->expectException( AuthenticationException::class );
+		$this->expectExceptionMessage( 'Authentication information must be provided' );
+		$cf->settings();
+	}
+
 	public function testShouldReturnSettingsWhenZoneIdIsSet() {
-		$this->assertTrue( true );
+		list( $cf, $settings ) = $this->getMocksWithDep( 'settings' );
+
+		$cf->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$settings->shouldReceive( 'settings' )
+		         ->once()
+		         ->with( 'zone1234' )
+		         ->andReturnUsing( function() {
+			         return (object) [
+				         'result'  => [
+					         // List of settings
+					         (object) [],
+					         (object) [],
+					         (object) [],
+					         (object) [],
+					         (object) [],
+				         ],
+				         'success' => true,
+				         'errors'  => [],
+			         ];
+		         } );
+
+		$response = $cf->settings();
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->errors );
+		$this->assertGreaterThan( 4, $response->result );
 	}
 }

--- a/Tests/Unit/CloudflareFacade/settings.php
+++ b/Tests/Unit/CloudflareFacade/settings.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Unit\CloudflareFacade;
+
+use WPMedia\Cloudflare\Tests\Unit\TestCase;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareFacade::settings
+ * @group  Cloudflare
+ * @group  CloudflareFacade
+ */
+class Test_Settings extends TestCase {
+
+	public function testShouldReturnSettingsWhenZoneIdIsSet() {
+		$this->assertTrue( true );
+	}
+}

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -3,6 +3,8 @@
 namespace WPMedia\Cloudflare\Tests\Unit;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use WPMedia\Cloudflare\Tests\TestCaseTrait;
@@ -41,7 +43,7 @@ abstract class TestCase extends PHPUnitTestCase {
 	 * Mock common WP functions.
 	 */
 	protected function mockCommonWpFunctions() {
-		Monkey\Functions\stubs(
+		Functions\stubs(
 			[
 				'__',
 				'esc_attr__',
@@ -66,7 +68,14 @@ abstract class TestCase extends PHPUnitTestCase {
 		];
 
 		foreach ( $functions as $function ) {
-			Monkey\Functions\when( $function )->echoArg();
+			Functions\when( $function )->echoArg();
 		}
+	}
+
+	protected function getFacade( $api_mock ) {
+		$mock = Mockery::mock( 'WPMedia\Cloudflare\CloudflareFacade[init_api_objects]', [ $api_mock ] )->shouldAllowMockingProtectedMethods();
+		$mock->shouldReceive( 'init_api_objects' )->andReturnNull();
+
+		return $mock;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,6 @@
 		"issues": "https://github.com/wp-media/cloudflare/issues",
 		"source": "https://github.com/wp-media/cloudflare"
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "git@github.com:wp-media/event-manager.git"
-		},
-		{
-			"type": "vcs",
-			"url": "git@github.com:wp-media/options.git"
-		}
-	],
     "require": {
 		"php": ">=5.6.0",
 		"jamesryanbell/cloudflare": "^1.11"
@@ -39,7 +29,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.0",
 		"phpunit/phpunit": "^5.7 || ^7",
 		"wp-coding-standards/wpcs": "^2",
-		"wp-media/event-manager": "^3.0",
+		"wp-media/event-manager": "^3.1",
 		"wp-media/options": "^3.0"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -227,34 +227,32 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.0",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.3,<8.0-DEV"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -274,12 +272,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "homepage": "https://github.com/doctrine/instantiator",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -396,28 +394,25 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
@@ -440,109 +435,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-01-17T21:11:47+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -706,33 +599,35 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -754,38 +649,79 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-10T14:09:06+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -805,55 +741,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -920,40 +808,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -968,7 +856,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -979,32 +867,29 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "php": ">=5.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
@@ -1019,7 +904,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -1029,7 +914,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1074,28 +959,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1110,7 +995,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -1119,33 +1004,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "~4.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1168,57 +1053,55 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
-                "sebastian/version": "^2.0.1"
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
+                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
-                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "~1.1"
             },
             "bin": [
                 "phpunit"
@@ -1226,7 +1109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -1252,7 +1135,67 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "abandoned": true,
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1301,30 +1244,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1355,39 +1298,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1412,40 +1354,34 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
+                "diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
-            },
-            "suggest": {
-                "ext-posix": "*"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1470,34 +1406,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1511,10 +1447,6 @@
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1523,12 +1455,16 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1537,27 +1473,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.2"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1565,7 +1501,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1588,34 +1524,33 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1635,77 +1570,32 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1733,29 +1623,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1775,7 +1665,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1930,44 +1820,63 @@
             "time": "2019-11-27T13:56:44+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "name": "symfony/yaml",
+            "version": "v3.4.37",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "aa46bc2233097d5212332c907f9911533acfbf80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/aa46bc2233097d5212332c907f9911533acfbf80",
+                "reference": "aa46bc2233097d5212332c907f9911533acfbf80",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
             "autoload": {
-                "classmap": [
-                    "src/"
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-13T08:00:59+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e769a01893216732de7fd05ca4c34bc3",
+    "content-hash": "d36db3f1ef032d1d33961caa586b5a35",
     "packages": [
         {
             "name": "jamesryanbell/cloudflare",
@@ -2068,66 +2068,26 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-media/event-manager.git",
-                "reference": "655b5146106399085471e95132077d6470dd09d7"
+                "reference": "dfc8b34397ea22fd92d0d98ce077479e3f20c597"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-media/event-manager/zipball/655b5146106399085471e95132077d6470dd09d7",
-                "reference": "655b5146106399085471e95132077d6470dd09d7",
+                "url": "https://api.github.com/repos/wp-media/event-manager/zipball/dfc8b34397ea22fd92d0d98ce077479e3f20c597",
+                "reference": "dfc8b34397ea22fd92d0d98ce077479e3f20c597",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6.0"
             },
-            "require-dev": {
-                "brain/monkey": "^2.0",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "php": "^5.6 || ^7",
-                "phpcompatibility/phpcompatibility-wp": "^2.0",
-                "phpunit/phpunit": "^5.7 || ^7",
-                "wp-coding-standards/wpcs": "^2"
-            },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "class-event-manager.php",
+                    "subscriber-interface.php",
                     "event-manager-aware-subscriber-interface.php",
-                    "subscriber-interface.php"
-                ],
-                "psr4": {
-                    "WP_Rocket\\Event_Management\\": "."
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "WPMedia\\EventManager\\Tests\\Unit\\": "tests/Unit",
-                    "WPMedia\\EventManager\\Tests\\Integration\\": "tests/Integration"
-                }
-            },
-            "scripts": {
-                "test-unit": [
-                    "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist"
-                ],
-                "test-integration": [
-                    "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist"
-                ],
-                "run-tests": [
-                    "@test-unit",
-                    "@test-integration"
-                ],
-                "install-codestandards": [
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-                ],
-                "phpcs": [
-                    "phpcs --basepath=."
-                ],
-                "phpcs-changed": [
-                    "./bin/phpcs-changed.sh"
-                ],
-                "phpcs:fix": [
-                    "phpcbf"
+                    "class-event-manager.php"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
             ],
@@ -2140,11 +2100,7 @@
             ],
             "description": "Cloudflare Addon",
             "homepage": "https://github.com/wp-media/event-manager",
-            "support": {
-                "issues": "https://github.com/wp-media/event-manager/issues",
-                "source": "https://github.com/wp-media/event-manager"
-            },
-            "time": "2020-01-24T14:09:20+00:00"
+            "time": "2020-01-25T22:18:46+00:00"
         },
         {
             "name": "wp-media/options",
@@ -2179,36 +2135,7 @@
                     "class-options-data.php"
                 ]
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "WPMedia\\Options\\Tests\\Unit\\": "tests/Unit",
-                    "WPMedia\\Options\\Tests\\Integration\\": "tests/Integration"
-                }
-            },
-            "scripts": {
-                "test-unit": [
-                    "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist"
-                ],
-                "test-integration": [
-                    "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist"
-                ],
-                "run-tests": [
-                    "@test-unit",
-                    "@test-integration"
-                ],
-                "install-codestandards": [
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-                ],
-                "phpcs": [
-                    "phpcs --basepath=."
-                ],
-                "phpcs-changed": [
-                    "./bin/phpcs-changed.sh"
-                ],
-                "phpcs:fix": [
-                    "phpcbf"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
             ],
@@ -2221,10 +2148,6 @@
             ],
             "description": "Options Handler for WordPress Options API Addon",
             "homepage": "https://github.com/wp-media/cloudflare",
-            "support": {
-                "issues": "https://github.com/wp-media/cloudflare/issues",
-                "source": "https://github.com/wp-media/cloudflare"
-            },
             "time": "2020-01-23T20:12:16+00:00"
         }
     ],


### PR DESCRIPTION
This PR does the following:

- adds the missing unit and integration tests for `CloudflareFacade`
- injects `Api` into `CloudflareFacade`, allowing `Api` to be mocked.
- moves the other dependencies into a protected function `init_api_objects()`. Why? To provide the means to mock the dependency objects.
- uses Packagists for `wp-media/options` and `wp-media/event-manager` instead of bringing those dependencies in through the GitHub `vcs`.  Why? vcs causes way too many Travis timeout problems, causing our builds to fail. Packagists is more reliable.