### PR TITLE
Added Cloudflare::auto_purge Integration Tests & Simplified CF tests

### DIFF
--- a/Tests/Integration/Cloudflare/TestCase.php
+++ b/Tests/Integration/Cloudflare/TestCase.php
@@ -20,11 +20,29 @@ abstract class TestCase extends BaseTestCase {
 		self::$options   = getFactory()->getContainer( 'options' );
 	}
 
+	public function tearDown() {
+		parent::tearDown();
+
+		getFactory()->resetToOriginalState();
+	}
+
 	protected function getSetting( $setting ) {
 		$response = self::$api->get( 'zones/' . self::$zone_id . '/settings/' . $setting );
 
 		if ( $response->success ) {
 			return $response->result->value;
 		}
+	}
+
+	protected function setInvalidApiCredentials( $do_cloudflare = true ) {
+		$data = [
+			'cloudflare_email'   => null,
+			'cloudflare_api_key' => null,
+			'cloudflare_zone_id' => null,
+			'do_cloudflare'      => $do_cloudflare,
+		];
+
+		update_option( 'wp_rocket_settings', $data );
+		self::$options->set_values( $data );
 	}
 }

--- a/Tests/Integration/Cloudflare/getCloudflareIPS.php
+++ b/Tests/Integration/Cloudflare/getCloudflareIPS.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPMedia\Cloudflare\Tests\Integration\Cloudflare;
 
 use WPMedia\Cloudflare\Cloudflare;
@@ -10,45 +11,24 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_GetCloudflareIPS extends TestCase {
 
 	public function testGetCloudflareIPSWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
+		$this->setInvalidApiCredentials();
 
 		$orig_cf_ips = get_transient( 'rocket_cloudflare_ips' );
-		self::$cf    = new Cloudflare( self::$options, self::$cf_facade );
-		$response    = self::$cf->get_cloudflare_ips();
+		$cf          = new Cloudflare( self::$options, self::$cf_facade );
+		$response    = $cf->get_cloudflare_ips();
 		$new_cf_ips  = get_transient( 'rocket_cloudflare_ips' );
 
 		$this->assertFalse( $orig_cf_ips );
 		$this->assertEquals( $response, $new_cf_ips );
 	}
 
-
 	public function testGetSettingsWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
+		$response  = self::$cf->get_cloudflare_ips();
+		$transient = get_transient( 'rocket_cloudflare_ips' );
 
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		$orig_cf_ips = get_transient( 'rocket_cloudflare_ips' );
-		self::$cf    = new Cloudflare( self::$options, self::$cf_facade );
-		$response    = self::$cf->get_cloudflare_ips();
-		$new_cf_ips  = get_transient( 'rocket_cloudflare_ips' );
-
-		$this->assertEquals( $response, $new_cf_ips );
-		remove_filter('site_url', $callback );
+		$this->assertTrue( $transient->success );
+		$this->assertTrue( $response->success );
+		$this->assertSame( $transient->result->ipv4_cidrs, $response->result->ipv4_cidrs );
+		$this->assertSame( $transient->result->ipv6_cidrs, $response->result->ipv6_cidrs );
 	}
-
 }

--- a/Tests/Integration/Cloudflare/getCloudflareInstance.php
+++ b/Tests/Integration/Cloudflare/getCloudflareInstance.php
@@ -11,32 +11,18 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_GetCloudflareInstance extends TestCase {
 
 	public function testWithCloudflareDisabled() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => false,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
+		$this->setInvalidApiCredentials( false );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertFalse( $is_api_keys_valid_cf );
 	}
 
 	public function testShouldSetCloudflareApiKeyTransientWhenCFCredentialsAreNull() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
+		$this->setInvalidApiCredentials();
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( is_wp_error( $is_api_keys_valid_cf ) );
@@ -52,7 +38,7 @@ class Test_GetCloudflareInstance extends TestCase {
 		update_option( 'wp_rocket_settings', $data );
 		self::$options->set_values( $data );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( is_wp_error( $is_api_keys_valid_cf ) );
@@ -68,7 +54,7 @@ class Test_GetCloudflareInstance extends TestCase {
 		update_option( 'wp_rocket_settings', $data );
 		self::$options->set_values( $data );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( is_wp_error( $is_api_keys_valid_cf ) );
@@ -85,7 +71,7 @@ class Test_GetCloudflareInstance extends TestCase {
 		update_option( 'wp_rocket_settings', $data );
 		self::$options->set_values( $data );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( is_wp_error( $is_api_keys_valid_cf ) );
@@ -105,7 +91,7 @@ class Test_GetCloudflareInstance extends TestCase {
 		$callback = function() { return 'https://example.org'; };
 		add_filter('site_url', $callback );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( is_wp_error( $is_api_keys_valid_cf ) );
@@ -127,7 +113,7 @@ class Test_GetCloudflareInstance extends TestCase {
 		$callback = function() { return self::$site_url; };
 		add_filter('site_url', $callback );
 
-		self::$cf             = new Cloudflare( self::$options, self::$cf_facade );
+		new Cloudflare( self::$options, self::$cf_facade );
 		$is_api_keys_valid_cf = get_transient( 'rocket_cloudflare_is_api_keys_valid' );
 
 		$this->assertTrue( $is_api_keys_valid_cf );

--- a/Tests/Integration/Cloudflare/getSettings.php
+++ b/Tests/Integration/Cloudflare/getSettings.php
@@ -11,44 +11,18 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_GetSettings extends TestCase {
 
 	public function testGetSettingsWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->get_settings();
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->get_settings();
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
-
 	public function testGetSettingsWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() {
-			return self::$site_url;
-		};
-		add_filter( 'site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$response = self::$cf->get_settings();
 
 		$this->assertSame( [ 'cache_level', 'minify', 'rocket_loader', 'browser_cache_ttl' ], array_keys( $response ) );
 		$this->assertTrue( 'on' === $response['minify'] || 'off' === $response['minify'] );
 		$this->assertContains( $response['browser_cache_ttl'], $this->getTTLValidValues() );
-
-		remove_filter( 'site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/hasPageRule.php
+++ b/Tests/Integration/Cloudflare/hasPageRule.php
@@ -10,38 +10,14 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_HasPageRule extends TestCase {
 
 	public function testHasPageRuleWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->has_page_rule( 'cache_everything' );
+		$this->setInvalidApiCredentials();
+		$cf = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->has_page_rule( 'cache_everything' );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testHasPageRuleWithSuccessButNoPageRule() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->has_page_rule( 'cache_everything' );
-
-		$this->assertEquals( 0, $response );
-		remove_filter('site_url', $callback );
+		$this->assertEquals( 0, self::$cf->has_page_rule( 'cache_everything' ) );
 	}
 }

--- a/Tests/Integration/Cloudflare/purgeByUrl.php
+++ b/Tests/Integration/Cloudflare/purgeByUrl.php
@@ -10,39 +10,19 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_PurgeByUrl extends TestCase {
 
 	public function testPurgeByUrlWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
+		$this->setInvalidApiCredentials();
 
-		self::$cf   = new Cloudflare( self::$options, self::$cf_facade );
+		$cf   = new Cloudflare( self::$options, self::$cf_facade );
 		$purge_urls = [
 			'/',
 			'/hello-world'
 		];
-		$response   = self::$cf->purge_by_url( null, $purge_urls, null );
+		$response   = $cf->purge_by_url( null, $purge_urls, null );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testPurgeByUrlWithPurgeError() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf   = new Cloudflare( self::$options, self::$cf_facade );
 		$purge_urls = [
 			'/',
 			'/hello-world'
@@ -51,6 +31,5 @@ class Test_PurgeByUrl extends TestCase {
 
 		$this->assertTrue( is_wp_error( $response ) );
 		$this->assertSame( 'cloudflare_purge_failed', $response->get_error_code() );
-		remove_filter('site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/purgeCloudflare.php
+++ b/Tests/Integration/Cloudflare/purgeCloudflare.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPMedia\Cloudflare\Tests\Integration\Cloudflare;
 
 use WPMedia\Cloudflare\Cloudflare;
@@ -10,38 +11,14 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_PurgeCloudflare extends TestCase {
 
 	public function testPurgeCloudflareWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->purge_cloudflare();
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->purge_cloudflare();
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testPurgeCloudflareWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->purge_cloudflare();
-
-		$this->assertTrue( $response );
-		remove_filter('site_url', $callback );
+		$this->assertTrue( self::$cf->purge_cloudflare() );
 	}
 }

--- a/Tests/Integration/Cloudflare/setBrowserCacheTTL.php
+++ b/Tests/Integration/Cloudflare/setBrowserCacheTTL.php
@@ -11,68 +11,26 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_SetBrowserCacheTTL extends TestCase {
 
 	public function testSetBrowserCacheTTLWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->set_browser_cache_ttl( 3600 );
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->set_browser_cache_ttl( 3600 );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testSetBrowserCacheTTLWithInvalidValue() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() {
-			return self::$site_url;
-		};
-		add_filter( 'site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$response = self::$cf->set_browser_cache_ttl( 29 );
 
 		$this->assertTrue( is_wp_error( $response ) );
 		$this->assertSame( 'cloudflare_browser_cache', $response->get_error_code() );
-
-		remove_filter( 'site_url', $callback );
 	}
 
 	public function testSetBrowserCacheTTLWithValidValue() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() {
-			return self::$site_url;
-		};
-		add_filter( 'site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$orig     = (int) $this->getSetting( 'browser_cache_ttl' );
 		$new_ttl  = $this->getNewTTL( $orig );
 		$response = self::$cf->set_browser_cache_ttl( $new_ttl );
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( $new_ttl, $response );
-
-		remove_filter( 'site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/setCacheLevel.php
+++ b/Tests/Integration/Cloudflare/setCacheLevel.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPMedia\Cloudflare\Tests\Integration\Cloudflare;
 
 use WPMedia\Cloudflare\Cloudflare;
@@ -10,58 +11,22 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_SetCacheLevel extends TestCase {
 
 	public function testSetCacheLevelWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$mode     = 'basic';
-		$response = self::$cf->set_cache_level( $mode );
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->set_cache_level( 'basic' );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testSetCacheLevelWithInvalidValue() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$mode     = 'invalid';
 		$response = self::$cf->set_cache_level( $mode );
 
 		$this->assertTrue( is_wp_error( $response ) );
 		$this->assertSame( 'cloudflare_cache_level', $response->get_error_code() );
-		remove_filter('site_url', $callback );
 	}
 
 	public function testSetCacheLevelWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf        = new Cloudflare( self::$options, self::$cf_facade );
 		//valid values: aggressive, basic, simplified
 		$orig     = $this->getSetting( 'cache_level' );
 		$new_val  = $this->getNewCacheLevel( $orig );
@@ -69,7 +34,5 @@ class Test_SetCacheLevel extends TestCase {
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( $new_val, $response );
-
-		remove_filter('site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/setDevMode.php
+++ b/Tests/Integration/Cloudflare/setDevMode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPMedia\Cloudflare\Tests\Integration\Cloudflare;
 
 use WPMedia\Cloudflare\Cloudflare;
@@ -10,65 +11,27 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_SetDevMode extends TestCase {
 
 	public function testSetDevModeWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$response = self::$cf->set_devmode( false );
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->set_devmode( false );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testSetDevModeWithInvalidValue() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$new      = 'invalid';
 		$response = self::$cf->set_devmode( $new );
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( 'off', $response );
-
-		remove_filter('site_url', $callback );
 	}
 
 	public function testSetDevModeWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$orig     = $this->getSetting( 'development_mode' );
 		$new      = 'off' === $orig ? true : false;
 		$response = self::$cf->set_devmode( $new );
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( $new, 'off' === $response ? false : true );
-
-		remove_filter('site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/setMinify.php
+++ b/Tests/Integration/Cloudflare/setMinify.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPMedia\Cloudflare\Tests\Integration\Cloudflare;
 
 use WPMedia\Cloudflare\Cloudflare;
@@ -10,64 +11,27 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_SetMinify extends TestCase {
 
 	public function testSetMinifyWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$mode     = 'off';
-		$response = self::$cf->set_minify( $mode );
+		$this->setInvalidApiCredentials();
+		$cf       = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->set_minify( 'off' );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testSetMinifyWithInvalidValue() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$new      = 'invalid';
 		$response = self::$cf->set_minify( $new );
 
 		$this->assertTrue( is_wp_error( $response ) );
 		$this->assertSame( 'cloudflare_minification', $response->get_error_code() );
-		remove_filter('site_url', $callback );
 	}
 
 	public function testSetMinifyWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$orig     = $this->getSetting( 'minify' );
 		$new      = 'off' == $orig->js ? 'on' : 'off';
 		$response = self::$cf->set_minify( $new );
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( $new, $response );
-		remove_filter('site_url', $callback );
 	}
 }

--- a/Tests/Integration/Cloudflare/setRocketLoader.php
+++ b/Tests/Integration/Cloudflare/setRocketLoader.php
@@ -10,43 +10,19 @@ use WPMedia\Cloudflare\Cloudflare;
 class Test_SetRocketLoader extends TestCase {
 
 	public function testSetRocketLoaderWithAPIError() {
-		$data = [
-			'cloudflare_email'   => null,
-			'cloudflare_api_key' => null,
-			'cloudflare_zone_id' => null,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
-		$mode     = 'off';
-		$response = self::$cf->set_rocket_loader( $mode );
+		$this->setInvalidApiCredentials();
+		$cf = new Cloudflare( self::$options, self::$cf_facade );
+		$response = $cf->set_rocket_loader( 'off' );
 
 		$this->assertTrue( is_wp_error( $response ) );
 	}
 
 	public function testSetRocketLoaderWithSuccess() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => true,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		$callback = function() { return self::$site_url; };
-		add_filter('site_url', $callback );
-
-		self::$cf = new Cloudflare( self::$options, self::$cf_facade );
 		$orig     = $this->getSetting( 'rocket_loader' );
 		$new      = 'off' == $orig ? 'on' : 'off';
 		$response = self::$cf->set_rocket_loader( $new );
 
 		$this->assertFalse( is_wp_error( $response ) );
 		$this->assertSame( $new, $response );
-
-		remove_filter('site_url', $callback );
 	}
 }

--- a/Tests/Integration/CloudflareSubscriber/autoPurge.php
+++ b/Tests/Integration/CloudflareSubscriber/autoPurge.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\CloudflareSubscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\Cloudflare\Tests\Integration\TestCase;
+use function WPMedia\Cloudflare\Tests\Integration\getFactory;
+
+/**
+ * @covers WPMedia\Cloudflare\CloudflareSubscriber::auto_purge
+ * @group  Subscriber
+ */
+class Test_AutoPurge extends TestCase {
+	private static $options;
+	private static $cf;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$cf      = getFactory()->getContainer( 'cloudflare' );
+		self::$options = getFactory()->getContainer( 'options' );
+	}
+
+	public function testShouldBailoutWhenCFAddonOff() {
+		$data = [ 'do_cloudflare' => 0 ];
+		update_option( 'wp_rocket_settings', $data );
+		self::$options->set_values( $data );
+
+		Functions\expect( 'current_user_can' )->with( 'rocket_purge_cloudflare_cache' )->never();
+		Functions\expect( 'is_wp_error' )->never();
+
+		do_action( 'after_rocket_clean_domain' );
+
+		$this->assertTrue( true ); // placeholder for risky tests.
+	}
+
+	public function testShouldBailoutWhenUserCantPurgeCF() {
+		$data = [ 'do_cloudflare' => 1 ];
+		update_option( 'wp_rocket_settings', $data );
+		self::$options->set_values( $data );
+
+		$user = $this->factory->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user );
+
+		Functions\expect( 'is_wp_error' )->never();
+
+		do_action( 'after_rocket_clean_domain' );
+
+		$this->assertTrue( true ); // placeholder for risky tests.
+	}
+
+	public function testShouldBailoutWhenNoPageRule() {
+		$data = [
+			'cloudflare_email'   => self::$email,
+			'cloudflare_api_key' => self::$api_key,
+			'cloudflare_zone_id' => self::$zone_id,
+			'do_cloudflare'      => 1,
+		];
+		update_option( 'wp_rocket_settings', $data );
+		self::$options->set_values( $data );
+
+		add_filter( 'site_url', [ $this, 'setSiteUrl' ] );
+
+		$admin = get_role( 'administrator' );
+		$admin->add_cap( 'rocket_purge_cloudflare_cache' );
+		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user );
+
+		Functions\expect( 'is_wp_error' )
+			->ordered()
+			->once()
+			->with( null )
+			->andAlsoExpectIt()
+			->once()
+			->with( 0 );
+
+		do_action( 'after_rocket_clean_domain' );
+
+		$this->assertTrue( true ); // placeholder for risky tests.
+
+		remove_filter( 'site_url', [ $this, 'setSiteUrl' ] );
+	}
+
+	public function setSiteUrl() {
+		return self::$site_url;
+	}
+}

--- a/Tests/Integration/CloudflareSubscriber/autoPurge.php
+++ b/Tests/Integration/CloudflareSubscriber/autoPurge.php
@@ -30,8 +30,6 @@ class Test_AutoPurge extends TestCase {
 		Functions\expect( 'is_wp_error' )->never();
 
 		do_action( 'after_rocket_clean_domain' );
-
-		$this->assertTrue( true ); // placeholder for risky tests.
 	}
 
 	public function testShouldBailoutWhenUserCantPurgeCF() {
@@ -45,8 +43,6 @@ class Test_AutoPurge extends TestCase {
 		Functions\expect( 'is_wp_error' )->never();
 
 		do_action( 'after_rocket_clean_domain' );
-
-		$this->assertTrue( true ); // placeholder for risky tests.
 	}
 
 	public function testShouldBailoutWhenNoPageRule() {
@@ -75,8 +71,6 @@ class Test_AutoPurge extends TestCase {
 			->with( 0 );
 
 		do_action( 'after_rocket_clean_domain' );
-
-		$this->assertTrue( true ); // placeholder for risky tests.
 
 		remove_filter( 'site_url', [ $this, 'setSiteUrl' ] );
 	}

--- a/Tests/Integration/CloudflareSubscriber/autoPurge.php
+++ b/Tests/Integration/CloudflareSubscriber/autoPurge.php
@@ -33,10 +33,6 @@ class Test_AutoPurge extends TestCase {
 	}
 
 	public function testShouldBailoutWhenUserCantPurgeCF() {
-		$data = [ 'do_cloudflare' => 1 ];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
 		$user = $this->factory->user->create( [ 'role' => 'contributor' ] );
 		wp_set_current_user( $user );
 
@@ -46,17 +42,6 @@ class Test_AutoPurge extends TestCase {
 	}
 
 	public function testShouldBailoutWhenNoPageRule() {
-		$data = [
-			'cloudflare_email'   => self::$email,
-			'cloudflare_api_key' => self::$api_key,
-			'cloudflare_zone_id' => self::$zone_id,
-			'do_cloudflare'      => 1,
-		];
-		update_option( 'wp_rocket_settings', $data );
-		self::$options->set_values( $data );
-
-		add_filter( 'site_url', [ $this, 'setSiteUrl' ] );
-
 		$admin = get_role( 'administrator' );
 		$admin->add_cap( 'rocket_purge_cloudflare_cache' );
 		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
@@ -71,11 +56,5 @@ class Test_AutoPurge extends TestCase {
 			->with( 0 );
 
 		do_action( 'after_rocket_clean_domain' );
-
-		remove_filter( 'site_url', [ $this, 'setSiteUrl' ] );
-	}
-
-	public function setSiteUrl() {
-		return self::$site_url;
 	}
 }

--- a/Tests/Integration/Factory.php
+++ b/Tests/Integration/Factory.php
@@ -29,7 +29,7 @@ class Factory {
 		add_filter( 'site_url', [ $this, 'setSiteUrl' ] );
 
 		$this->setUpApiCredentials();
-		$this->addOptions();
+		$this->resetToOriginalState();
 		$this->initContainer();
 
 		remove_filter( 'site_url', [ $this, 'setSiteUrl' ] );
@@ -47,25 +47,43 @@ class Factory {
 		self::$site_url                    = self::getApiCredential( 'ROCKET_CLOUDFLARE_SITE_URL' );
 	}
 
+	public function resetToOriginalState() {
+		$transients = [
+			'rocket_cloudflare_is_api_keys_valid',
+			'rocket_cloudflare_ips',
+		];
+		foreach ( $transients as $transient ) {
+			delete_transient( $transient );
+		}
+
+		$this->addOptions();
+	}
+
 	private function addOptions() {
-		update_option(
-			'wp_rocket_settings',
-			[
-				'cdn'                         => 0,
-				'cdn_cnames'                  => [],
-				'cdn_zone'                    => [],
-				'cdn_reject_files'            => [],
-				'do_cloudflare'               => 1,
-				'cloudflare_email'            => self::$email,
-				'cloudflare_api_key'          => self::$api_key,
-				'cloudflare_zone_id'          => self::$zone_id,
-				'cloudflare_devmode'          => 0,
-				'cloudflare_protocol_rewrite' => 0,
-				'cloudflare_auto_settings'    => 0,
-				'cloudflare_old_settings'     => '',
-				'varnish_auto_purge'          => 0,
-			]
-		);
+		$options = $this->getOptions();
+		update_option( 'wp_rocket_settings', $options );
+
+		if ( isset( $this->container['options'] ) ) {
+			$this->container['options']->set_values( $options );
+		}
+	}
+
+	public function getOptions() {
+		return [
+			'cdn'                         => 0,
+			'cdn_cnames'                  => [],
+			'cdn_zone'                    => [],
+			'cdn_reject_files'            => [],
+			'do_cloudflare'               => 1,
+			'cloudflare_email'            => self::$email,
+			'cloudflare_api_key'          => self::$api_key,
+			'cloudflare_zone_id'          => self::$zone_id,
+			'cloudflare_devmode'          => 0,
+			'cloudflare_protocol_rewrite' => 0,
+			'cloudflare_auto_settings'    => 0,
+			'cloudflare_old_settings'     => '',
+			'varnish_auto_purge'          => 0,
+		];
 	}
 
 	private function initContainer() {

--- a/Tests/Integration/TestCase.php
+++ b/Tests/Integration/TestCase.php
@@ -26,12 +26,10 @@ abstract class TestCase extends WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		// Set up the Cloudflare API's credentials.
-		self::$api_credentials_config_file = 'cloudflare.php';
-		self::$email                       = self::getApiCredential( 'ROCKET_CLOUDFLARE_EMAIL' );
-		self::$api_key                     = self::getApiCredential( 'ROCKET_CLOUDFLARE_API_KEY' );
-		self::$zone_id                     = self::getApiCredential( 'ROCKET_CLOUDFLARE_ZONE_ID' );
-		self::$site_url                    = self::getApiCredential( 'ROCKET_CLOUDFLARE_SITE_URL' );
+		self::$email    = Factory::$email;
+		self::$api_key  = Factory::$api_key;
+		self::$zone_id  = Factory::$zone_id;
+		self::$site_url = Factory::$site_url;
 	}
 
 	/**
@@ -61,24 +59,7 @@ abstract class TestCase extends WP_UnitTestCase {
 	 * @return string returns the value if available; else an empty string.
 	 */
 	protected static function getApiCredential( $name ) {
-		$var = getenv( $name );
-		if ( ! empty( $var ) ) {
-			return $var;
-		}
-
-		if ( ! self::$api_credentials_config_file ) {
-			return '';
-		}
-
-		$config_file = dirname( __DIR__ ) . '/env/local/cloudflare.php';
-		if ( ! is_readable( $config_file ) ) {
-			return '';
-		}
-
-		// This file is local to the developer's machine and not stored in the repo.
-		require_once $config_file;
-
-		return rocket_get_constant( $name, '' );
+		return Factory::getApiCredential( $name );
 	}
 
 	protected function getNewCacheLevel( $value ) {
@@ -89,7 +70,7 @@ abstract class TestCase extends WP_UnitTestCase {
 	}
 
 	protected function getNewTTL( $value ) {
-		$valid_ttls = $this->getTTLValidValues();
+		$valid_ttls        = $this->getTTLValidValues();
 		$without_given_ttl = array_values( array_diff( $valid_ttls, [ $value ] ) );
 
 		return $without_given_ttl[ rand( 0, count( $without_given_ttl ) - 1 ) ];
@@ -99,7 +80,7 @@ abstract class TestCase extends WP_UnitTestCase {
 		return [
 			'aggressive',
 			'basic',
-			'simplified'
+			'simplified',
 		];
 	}
 

--- a/Tests/Integration/TestCase.php
+++ b/Tests/Integration/TestCase.php
@@ -3,11 +3,13 @@
 namespace WPMedia\Cloudflare\Tests\Integration;
 
 use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use WPMedia\Cloudflare\Tests\TestCaseTrait;
 use WP_UnitTestCase;
 
 abstract class TestCase extends WP_UnitTestCase {
 	use TestCaseTrait;
+	use MockeryPHPUnitIntegration;
 
 	protected static $api_key;
 	protected static $email;

--- a/Tests/TestCaseTrait.php
+++ b/Tests/TestCaseTrait.php
@@ -2,12 +2,13 @@
 
 namespace WPMedia\Cloudflare\Tests;
 
-use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
 
 trait TestCaseTrait {
+	use MockeryPHPUnitIntegration;
 
 	protected static function stubRocketFunctions() {
 		require_once __DIR__ . '/Fixtures/functions.php';

--- a/Tests/TestCaseTrait.php
+++ b/Tests/TestCaseTrait.php
@@ -2,13 +2,11 @@
 
 namespace WPMedia\Cloudflare\Tests;
 
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
 
 trait TestCaseTrait {
-	use MockeryPHPUnitIntegration;
 
 	protected static function stubRocketFunctions() {
 		require_once __DIR__ . '/Fixtures/functions.php';


### PR DESCRIPTION
1. Improved the Factory:
    - Moved the API credentials to it
    - Set up the normal initial state with the API credentials in the options
    - Added a reset method allowing tests to reset back to the starting state
2. Added the missing integration test for `Cloudflare::auto_purge`.
3. Simplified the `Cloudflare` integration tests by:
    - Removing the object creation and set up within each test. Use the factory instead.
    - Moved the API credentials set up code to the `TestCase`. Simplified the first test in each class.