### PR TITLE
Updates for new changes in wpmedia/phpunit. Makes code phpcs compliant.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,15 @@
 bin export-ignore
-tests export-ignore
+Tests export-ignore
 vendor export-ignore
 
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .github export-ignore
-composer.lock
+.prettyci.composer.json export-ignore
+.travis.yml export-ignore
+
+composer.lock export-ignore
 LICENSE.md export-ignore
 phpcs.xml export-ignore
-.prettyci.composer.json export-ignore
 README.md export-ignore
-.travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@ vendor export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .github export-ignore
-.prettyci.composer.json export-ignore
 .travis.yml export-ignore
 
 composer.lock export-ignore

--- a/.prettyci.composer.json
+++ b/.prettyci.composer.json
@@ -1,7 +1,0 @@
-{
-    "require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.0",
-		"wp-coding-standards/wpcs": "^2.1.0"
-	}
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,38 +9,47 @@ notifications:
     on_failure: never
 branches:
   only:
-  - master
-  - develop
-  - /branch-.*$/
+    - master
+    - develop
+    - /branch-.*$/
 cache:
   directories:
-  - vendor
-  - "$HOME/.composer/cache"
+    - vendor
+    - $HOME/.composer/cache
 matrix:
+  fast_finish: true
   include:
-  - php: 7.4
-    env: WP_VERSION=latest
-  - php: 7.3
-    env: WP_VERSION=latest
-  - php: 7.2
-    env: WP_VERSION=latest
-  - php: 5.6
-    env: WP_VERSION=4.9.11
-  - php: 5.6
-    env: WP_VERSION=latest
+    - php: 7.4
+      env: WP_VERSION=latest
+    - php: 7.3
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=latest
+    - php: 5.6
+      env: WP_VERSION=latest
+    - name: Legacy
+      php: 5.6
+      env: WP_VERSION=4.9.11
+    - name: Coding Standards
+      php: 7.3
+      env: WP_TRAVISCI=phpcs
+before_install:
+  # Unless we need XDebug, disable it for improved performance.
+  - phpenv config-rm xdebug.ini || return 0
+  - rm composer.lock
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - composer remove --dev phpstan/phpstan szepeviktor/phpstan-wordpress
+install:
+  - composer install --prefer-dist --no-interaction
 before_script:
-- rm composer.lock
-- export PATH="$HOME/.composer/vendor/bin:$PATH"
-- composer install --no-progress
-- |
-  if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-    phpenv config-rm xdebug.ini
-  else
-    echo "xdebug.ini does not exist"
-  fi
-- |
-  if [[ ! -z "$WP_VERSION" ]] ; then
-    bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-  fi
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    fi
 script:
-- composer run-tests
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]]; then
+      composer phpcs
+    else
+      composer run-tests
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ branches:
   only:
     - master
     - develop
-    - /branch-.*$/
 cache:
   directories:
     - vendor

--- a/APIClient.php
+++ b/APIClient.php
@@ -5,7 +5,9 @@ namespace WPMedia\Cloudflare;
 use stdClass;
 
 /**
- * @since  3.5
+ * Cloudflare API Client.
+ *
+ * @since 3.5
  */
 class APIClient {
 	const CLOUDFLARE_API = 'https://api.cloudflare.com/client/v4/';
@@ -239,8 +241,8 @@ class APIClient {
 	 *
 	 * @since 3.5
 	 *
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
+	 * @param string $path Path of the endpoint.
+	 * @param array  $data Data to be sent along with the request.
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -253,10 +255,10 @@ class APIClient {
 	 *
 	 * @since 3.5
 	 *
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
+	 * @param string $path Path of the endpoint.
+	 * @param array  $data Data to be sent along with the request.
 	 *
-	 * @return mixed
+	 * @return stdClass Cloudflare response packet.
 	 */
 	protected function delete( $path, array $data = [] ) {
 		return $this->request( $path, $data, 'delete' );
@@ -267,10 +269,10 @@ class APIClient {
 	 *
 	 * @since 3.5
 	 *
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
+	 * @param string $path Path of the endpoint.
+	 * @param array  $data Data to be sent along with the request.
 	 *
-	 * @return mixed
+	 * @return stdClass Cloudflare response packet.
 	 */
 	protected function patch( $path, array $data = [] ) {
 		return $this->request( $path, $data, 'patch' );
@@ -289,18 +291,18 @@ class APIClient {
 	 * @param string $method Type of method that should be used ('GET', 'DELETE', 'PATCH').
 	 *
 	 * @return stdClass response object.
-	 * @throws AuthenticationException when email or api key are not set.
-	 * @throws UnauthorizedException when Cloudflare's API returns a 401 or 403.
+	 * @throws AuthenticationException When email or api key are not set.
+	 * @throws UnauthorizedException When Cloudflare's API returns a 401 or 403.
 	 */
 	protected function request( $path, array $data = [], $method = 'get' ) {
 		if ( ! $this->is_authorized() ) {
-			throw new AuthenticationException( __( 'Authentication information must be provided', 'cloudflare' ) );
+			throw new AuthenticationException( 'Authentication information must be provided.' );
 		}
 
 		list( $http_result, $error, $information, $http_code ) = $this->do_remote_request( $path, $data, $method );
 
-		if ( in_array( $http_code, [ 401, 403 ] ) ) {
-			throw new UnauthorizedException( __( 'You do not have permission to perform this request,', 'cloudflare' ) );
+		if ( in_array( $http_code, [ 401, 403 ], true ) ) {
+			throw new UnauthorizedException( 'You do not have permission to perform this request.' );
 		}
 
 		$response = json_decode( $http_result );
@@ -355,7 +357,6 @@ class APIClient {
 			$method
 		);
 
-
 		$packet = [
 			curl_exec( $ch ),
 			curl_error( $ch ),
@@ -384,7 +385,7 @@ class APIClient {
 		if ( 'get' === $method ) {
 			$url .= '?' . http_build_query( $data );
 		} else {
-			curl_setopt( $ch, CURLOPT_POSTFIELDS, json_encode( $data ) );
+			curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $data ) );
 			curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, strtoupper( $method ) );
 		}
 

--- a/AuthenticationException.php
+++ b/AuthenticationException.php
@@ -4,4 +4,5 @@ namespace WPMedia\Cloudflare;
 
 use RuntimeException;
 
-class AuthenticationException extends RuntimeException {}
+class AuthenticationException extends RuntimeException {
+}

--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -2,6 +2,7 @@
 
 namespace WPMedia\Cloudflare;
 
+use WP_Error;
 use WP_Rocket\Admin\Options_Data;
 
 /**
@@ -13,7 +14,7 @@ use WP_Rocket\Admin\Options_Data;
 class Cloudflare {
 
 	/**
-	 * WP Rocket options instance.
+	 * Options Data instance.
 	 *
 	 * @var Options_Data
 	 */
@@ -120,13 +121,13 @@ class Cloudflare {
 
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
-					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-					// translators: Documentation exists in EN, FR; use localized URL if applicable.
-					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-					'</a>'
-				);
+				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+				// translators: Documentation exists in EN, FR; use localized URL if applicable.
+				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+				'</a>'
+			);
 
-			return new \WP_Error( 'cloudflare_no_zone_id', $msg );
+			return new WP_Error( 'cloudflare_no_zone_id', $msg );
 		}
 
 		try {
@@ -141,13 +142,13 @@ class Cloudflare {
 
 						$msg .= ' ' . sprintf(
 							/* translators: %1$s = opening link; %2$s = closing link */
-								__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-								// translators: Documentation exists in EN, FR; use localized URL if applicable.
-								'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-								'</a>'
-							);
+							__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+							// translators: Documentation exists in EN, FR; use localized URL if applicable.
+							'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+							'</a>'
+						);
 
-						return new \WP_Error( 'cloudflare_invalid_auth', $msg );
+						return new WP_Error( 'cloudflare_invalid_auth', $msg );
 					}
 				}
 
@@ -155,13 +156,13 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-						// translators: Documentation exists in EN, FR; use localized URL if applicable.
-						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-						'</a>'
-					);
+					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+					// translators: Documentation exists in EN, FR; use localized URL if applicable.
+					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+					'</a>'
+				);
 
-				return new \WP_Error( 'cloudflare_invalid_auth', $msg );
+				return new WP_Error( 'cloudflare_invalid_auth', $msg );
 			}
 
 			$zone_found = false;
@@ -183,27 +184,27 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-						// translators: Documentation exists in EN, FR; use localized URL if applicable.
-						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-						'</a>'
-					);
-
-				return new \WP_Error( 'cloudflare_wrong_zone_id', $msg );
-			}
-
-			return true;
-		} catch ( \Exception $e ) {
-			$msg = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
-			$msg .= ' ' . sprintf(
-				/* translators: %1$s = opening link; %2$s = closing link */
 					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
 					// translators: Documentation exists in EN, FR; use localized URL if applicable.
 					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
 					'</a>'
 				);
 
-			return new \WP_Error( 'cloudflare_invalid_auth', $msg );
+				return new WP_Error( 'cloudflare_wrong_zone_id', $msg );
+			}
+
+			return true;
+		} catch ( \Exception $e ) {
+			$msg  = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
+			$msg .= ' ' . sprintf(
+				/* translators: %1$s = opening link; %2$s = closing link */
+				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+				// translators: Documentation exists in EN, FR; use localized URL if applicable.
+				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+				'</a>'
+			);
+
+			return new WP_Error( 'cloudflare_invalid_auth', $msg );
 		}
 	}
 

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -17,6 +17,9 @@ abstract class TestCase extends WPMediaTestCase {
 		parent::setUp();
 
 		rocket_get_constant( 'WP_ROCKET_VERSION', '3.5' );
+
+		Functions\stubs( [ 'sanitize_text_field' ] );
+
 	}
 
 	protected function getAPIMock() {

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -2,15 +2,18 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit;
 
-use Brain\Monkey;
 use Mockery;
-use WPMedia\PHPUnit\Unit\TestCase as BaseTestCase;
+use WPMedia\PHPUnit\Unit\TestCase as WPMediaTestCase;
 
-abstract class TestCase extends BaseTestCase {
+abstract class TestCase extends WPMediaTestCase {
+	protected static $stubPolyfills = true;
+	protected static $mockCommonWpFunctionsInSetUp = true;
 
+	/**
+	 * Prepares the test environment before each test.
+	 */
 	protected function setUp() {
 		parent::setUp();
-		Monkey\setUp();
 
 		rocket_get_constant( 'WP_ROCKET_VERSION', '3.5' );
 	}

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace WPMedia\Cloudflare\Tests\Unit;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\PHPUnit\Unit\TestCase as WPMediaTestCase;
 

--- a/composer.lock
+++ b/composer.lock
@@ -288,6 +288,52 @@
             "time": "2016-01-20T08:20:44+00:00"
         },
         {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-10-30T15:31:00+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.3.1",
             "source": {
@@ -716,41 +762,38 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -761,10 +804,14 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
+            "time": "2020-02-09T09:16:15+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2114,16 +2161,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-media/phpunit.git",
-                "reference": "274fa27017cde1eea21737d706282d8434670278"
+                "reference": "766715679911ff453d5686c6d7befc395a9f452a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/274fa27017cde1eea21737d706282d8434670278",
-                "reference": "274fa27017cde1eea21737d706282d8434670278",
+                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/766715679911ff453d5686c6d7befc395a9f452a",
+                "reference": "766715679911ff453d5686c6d7befc395a9f452a",
                 "shasum": ""
             },
-            "require-dev": {
+            "require": {
                 "brain/monkey": "^2.0",
+                "mikey179/vfsstream": "^1.6",
                 "php": "^5.6 || ^7",
                 "phpunit/phpunit": "^5.7 || ^7"
             },
@@ -2131,6 +2179,11 @@
                 "wpmedia-phpunit"
             ],
             "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WPMedia\\PHPUnit\\": "."
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
@@ -2142,9 +2195,9 @@
                     "homepage": "https://wp-media.me"
                 }
             ],
-            "description": "PHPUnit extender for our common test suite bootstrapping.",
+            "description": "PHPUnit extender for bootstrapping unit and WordPress integration test suites.",
             "homepage": "https://github.com/wp-media/phpunit",
-            "time": "2020-02-05T23:43:22+00:00"
+            "time": "2020-02-12T20:10:29+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WP Rocket" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
-	<description>The custom ruleset for WP Rocket.</description>
+	<description>The custom ruleset for WPMedia.</description>
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
@@ -9,8 +9,6 @@
 
 	<file>.</file>
 	<!-- Ignoring Files and Folders: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
-	<exclude-pattern>/inc/deprecated/*</exclude-pattern>
-	<exclude-pattern>/inc/vendors/*</exclude-pattern>
 	<exclude-pattern>/tests/Integration/*</exclude-pattern>
 	<exclude-pattern>/tests/Unit/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
@@ -28,14 +26,15 @@
 	<config name="minimum_supported_wp_version" value="4.7"/>
 
 	<rule ref="WordPress">
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
-		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged"/>
-        <exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
-        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-        <exclude name="Squiz.Commenting.FileComment.Missing"/>
-        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
-        <exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<!-- Allow cURL. -->
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_init" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_exec" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_error" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_getinfo" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_close" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_setopt_array" />
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_setopt" />
 	</rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
@@ -44,7 +43,7 @@
     </rule>
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
         <properties>
-            <property name="prefixes" type="array" value="rocket,wp_rocket" />
+            <property name="prefixes" type="array" value="WPMedia, ROCKET" />
         </properties>
     </rule>
     <rule ref="WordPress.Files.FileName">
@@ -52,44 +51,11 @@
             <property name="strict_class_file_names" value="false" />
         </properties>
     </rule>
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_readfile">
-		<exclude-pattern>inc/classes/buffer/class-cache.php</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged">
-		<exclude-pattern>inc/admin/admin.php</exclude-pattern>
-		<exclude-pattern>inc/front/process.php</exclude-pattern>
-		<exclude-pattern>uninstall.php</exclude-pattern>
-		<exclude-pattern>inc/classes/buffer/class-cache.php</exclude-pattern>
-		<exclude-pattern>inc/classes/admin/class-logs.php</exclude-pattern>
-		<exclude-pattern>inc/classes/logger/class-stream-handler.php</exclude-pattern>
-		<exclude-pattern>inc/classes/logger/class-logger.php</exclude-pattern>
-		<exclude-pattern>inc/classes/subscriber/third-party/Hostings/class-litespeed-subscriber.php</exclude-pattern>
-		<exclude-pattern>inc/classes/subscriber/third-party/plugins/ecommerce/class-woocommerce-subscriber.php</exclude-pattern>
-		<exclude-pattern>inc/classes/subscriber/third-party/plugins/security/class-sucuri-subscriber.php</exclude-pattern>
-	</rule>
 
-	<rule ref="WordPress.DB.DirectDatabaseQuery.DirectQuery">
-		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
-		<exclude-pattern>inc/classes/admin/Database/class-optimization.php</exclude-pattern>
-		<exclude-pattern>inc/classes/optimization/CSS/class-critical-css.php</exclude-pattern>
+	<rule ref="WordPress-Docs">
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
 	</rule>
-
-	<rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
-		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
-		<exclude-pattern>inc/classes/admin/Database/class-optimization.php</exclude-pattern>
-		<exclude-pattern>inc/classes/optimization/CSS/class-critical-css.php</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.DB.PreparedSQL.NotPrepared">
-		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
-		<exclude-pattern>inc/classes/admin/Database/class-optimization.php</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.DB.PreparedSQL.InterpolatedNotPrepared">
-		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
-		<exclude-pattern>inc/classes/optimization/CSS/class-critical-css.php</exclude-pattern>
-	</rule>
-	<rule ref="WordPress-Docs"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards


### PR DESCRIPTION
- Turns on the polyfills from `wp-media/phpunit` base test case
- Turns on the mock for common WP functions from `wp-media/phpunit` base test case
- Fixes all code problems for WPCS/PHPCS. w00t!
- Adds the new travis configuration from Rocket, which includes running phpcs.
- Fixes the gitattributes, making it ready for usage.