### PR TITLE
Updates the `@since` version to 1.0.

### DIFF
--- a/APIClient.php
+++ b/APIClient.php
@@ -7,7 +7,7 @@ use stdClass;
 /**
  * Cloudflare API Client.
  *
- * @since 3.5
+ * @since 1.0
  */
 class APIClient {
 	const CLOUDFLARE_API = 'https://api.cloudflare.com/client/v4/';
@@ -50,6 +50,8 @@ class APIClient {
 	/**
 	 * APIClient constructor.
 	 *
+	 * @since 1.0
+	 *
 	 * @param string $useragent The user agent for this plugin or package. For example, "wp-rocket/3.5".
 	 */
 	public function __construct( $useragent ) {
@@ -74,7 +76,7 @@ class APIClient {
 	/**
 	 * Sets up the API credentials.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $email   The email associated with the Cloudflare account.
 	 * @param string $api_key The API key for the associated Cloudflare account.
@@ -92,7 +94,7 @@ class APIClient {
 	/**
 	 * Get zone data.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -103,7 +105,7 @@ class APIClient {
 	/**
 	 * Get the zone's page rules.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -114,7 +116,7 @@ class APIClient {
 	/**
 	 * Purges the cache.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -125,7 +127,7 @@ class APIClient {
 	/**
 	 * Purges the given URLs.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param array|null $urls An array of URLs that should be removed from cache.
 	 *
@@ -138,7 +140,7 @@ class APIClient {
 	/**
 	 * Changes the zone's browser cache TTL setting.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $value New setting's value.
 	 *
@@ -151,7 +153,7 @@ class APIClient {
 	/**
 	 * Changes the zone's rocket loader setting.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $value New setting's value.
 	 *
@@ -164,7 +166,7 @@ class APIClient {
 	/**
 	 * Changes the zone's minify setting.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $value New setting's value.
 	 *
@@ -177,7 +179,7 @@ class APIClient {
 	/**
 	 * Changes the zone's cache level.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $value New setting's value.
 	 *
@@ -190,7 +192,7 @@ class APIClient {
 	/**
 	 * Changes the zone's development mode.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $value New setting's value.
 	 *
@@ -203,7 +205,7 @@ class APIClient {
 	/**
 	 * Changes the given setting.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @param string $setting Name of the setting to change.
 	 * @param string $value   New setting's value.
@@ -217,7 +219,7 @@ class APIClient {
 	/**
 	 * Gets all of the Cloudflare settings.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -228,7 +230,7 @@ class APIClient {
 	/**
 	 * Gets Cloudflare's IPs.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
 	 * @return stdClass Cloudflare response packet.
 	 */
@@ -239,7 +241,7 @@ class APIClient {
 	/**
 	 * API call method for sending requests using GET.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @param string $path Path of the endpoint.
 	 * @param array  $data Data to be sent along with the request.
@@ -253,7 +255,7 @@ class APIClient {
 	/**
 	 * API call method for sending requests using DELETE.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @param string $path Path of the endpoint.
 	 * @param array  $data Data to be sent along with the request.
@@ -267,7 +269,7 @@ class APIClient {
 	/**
 	 * API call method for sending requests using PATCH.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @param string $path Path of the endpoint.
 	 * @param array  $data Data to be sent along with the request.
@@ -281,9 +283,9 @@ class APIClient {
 	/**
 	 * API call method for sending requests using GET, POST, PUT, DELETE OR PATCH.
 	 *
-	 * @since  3.5
+	 * @since 1.0
 	 *
-	 * @author James Bell <james@james-bell.co.uk> - credit for original code adapted for version 3.5.
+	 * @author James Bell <james@james-bell.co.uk> - credit for original code adapted for version 1.0.
 	 * @author WP Media
 	 *
 	 * @param string $path   Path of the endpoint.
@@ -324,7 +326,7 @@ class APIClient {
 	/**
 	 * Checks if the email and API key for the API credentials are set.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @return bool true if authorized; else false.
 	 */
@@ -339,7 +341,7 @@ class APIClient {
 	/**
 	 * Does the request remote cURL request.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @param string $path   Path of the endpoint.
 	 * @param array  $data   Data to be sent along with the request.
@@ -372,7 +374,7 @@ class APIClient {
 	/**
 	 * Sets the cURL options.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @param resource $ch     cURL handle.
 	 * @param string   $url    Request route.

--- a/AuthenticationException.php
+++ b/AuthenticationException.php
@@ -4,5 +4,4 @@ namespace WPMedia\Cloudflare;
 
 use RuntimeException;
 
-class AuthenticationException extends RuntimeException {
-}
+class AuthenticationException extends RuntimeException {}

--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -2,6 +2,8 @@
 
 namespace WPMedia\Cloudflare;
 
+use Exception;
+use stdClass;
 use WP_Error;
 use WP_Rocket\Admin\Options_Data;
 
@@ -87,19 +89,19 @@ class Cloudflare {
 	 *
 	 * @since 1.0
 	 *
-	 * @param string $cf_email   - Cloudflare email.
-	 * @param string $cf_api_key - Cloudflare API key.
-	 * @param string $cf_zone_id - Cloudflare zone ID.
+	 * @param string $cf_email   Cloudflare email.
+	 * @param string $cf_api_key Cloudflare API key.
+	 * @param string $cf_zone_id Cloudflare zone ID.
 	 *
-	 * @return \stdClass true if credentials are ok, WP_Error otherwise.
+	 * @return stdClass true if credentials are ok, WP_Error otherwise.
 	 */
 	public function is_api_keys_valid( $cf_email, $cf_api_key, $cf_zone_id ) {
 		if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) ) {
-			return new \WP_Error( 'curl_disabled', __( 'Curl is disabled on your server. Please ask your host to enable it. This is required for the Cloudflare Add-on to work correctly.', 'rocket' ) );
+			return new WP_Error( 'curl_disabled', __( 'Curl is disabled on your server. Please ask your host to enable it. This is required for the Cloudflare Add-on to work correctly.', 'rocket' ) );
 		}
 
 		if ( empty( $cf_email ) || empty( $cf_api_key ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'cloudflare_credentials_empty',
 				sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
@@ -189,7 +191,7 @@ class Cloudflare {
 			}
 
 			return true;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$msg  = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
@@ -208,7 +210,7 @@ class Cloudflare {
 	 *
 	 * @since 1.0
 	 *
-	 * @param String $action_value - cache_everything.
+	 * @param string $action_value Cache_everything.
 	 *
 	 * @return mixed  Object|bool true / false if $action_value was found or not, WP_Error otherwise.
 	 */
@@ -227,14 +229,14 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_page_rule_failed', $errors );
+				return new WP_Error( 'cloudflare_page_rule_failed', $errors );
 			}
 
 			$cf_page_rule_arr = wp_json_encode( $cf_page_rule );
 
 			return preg_match( '/' . $action_value . '/', $cf_page_rule_arr );
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_page_rule_failed', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_page_rule_failed', $e->getMessage() );
 		}
 	}
 
@@ -260,12 +262,12 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_purge_failed', $errors );
+				return new WP_Error( 'cloudflare_purge_failed', $errors );
 			}
 
 			return true;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_purge_failed', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_purge_failed', $e->getMessage() );
 		}
 	}
 
@@ -295,13 +297,13 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_purge_failed', $errors );
+				return new WP_Error( 'cloudflare_purge_failed', $errors );
 			}
 
 			return true;
 
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_purge_failed', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_purge_failed', $e->getMessage() );
 		}
 	}
 
@@ -329,12 +331,12 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_browser_cache', $errors );
+				return new WP_Error( 'cloudflare_browser_cache', $errors );
 			}
 
 			return $mode;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_browser_cache', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_browser_cache', $e->getMessage() );
 		}
 	}
 
@@ -362,12 +364,12 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_rocket_loader', $errors );
+				return new WP_Error( 'cloudflare_rocket_loader', $errors );
 			}
 
 			return $mode;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_rocket_loader', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_rocket_loader', $e->getMessage() );
 		}
 	}
 
@@ -401,12 +403,12 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_minification', $errors );
+				return new WP_Error( 'cloudflare_minification', $errors );
 			}
 
 			return $mode;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_minification', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_minification', $e->getMessage() );
 		}
 	}
 
@@ -434,12 +436,12 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_cache_level', $errors );
+				return new WP_Error( 'cloudflare_cache_level', $errors );
 			}
 
 			return $mode;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_cache_level', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_cache_level', $e->getMessage() );
 		}
 	}
 
@@ -473,7 +475,7 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_dev_mode', $errors );
+				return new WP_Error( 'cloudflare_dev_mode', $errors );
 			}
 
 			if ( 'on' === $value ) {
@@ -481,8 +483,8 @@ class Cloudflare {
 			}
 
 			return $value;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_dev_mode', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_dev_mode', $e->getMessage() );
 		}
 	}
 
@@ -508,7 +510,7 @@ class Cloudflare {
 
 				$errors = wp_sprintf_l( '%l ', $errors );
 
-				return new \WP_Error( 'cloudflare_dev_mode', $errors );
+				return new WP_Error( 'cloudflare_dev_mode', $errors );
 			}
 
 			foreach ( $cf_settings->result as $cloudflare_option ) {
@@ -541,8 +543,8 @@ class Cloudflare {
 			];
 
 			return $cf_settings_array;
-		} catch ( \Exception $e ) {
-			return new \WP_Error( 'cloudflare_current_settings', $e->getMessage() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'cloudflare_current_settings', $e->getMessage() );
 		}
 	}
 
@@ -573,7 +575,7 @@ class Cloudflare {
 			}
 
 			set_transient( 'rocket_cloudflare_ips', $cf_ips, 2 * WEEK_IN_SECONDS );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			// Set default IPs from Cloudflare if call to Cloudflare /ips API fails.
 			// Prevents from making API calls on each page load.
 			$cf_ips = $this->get_default_ips();
@@ -590,7 +592,7 @@ class Cloudflare {
 	 *
 	 * @since 1.0
 	 *
-	 * @return \stdClass Default Cloudflare connecting IPs.
+	 * @return stdClass Default Cloudflare connecting IPs.
 	 */
 	private function get_default_ips() {
 		$cf_ips = (object) [

--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -8,8 +8,7 @@ use WP_Rocket\Admin\Options_Data;
 /**
  * Cloudflare
  *
- * @since  3.5
- * @author Soponar Cristina
+ * @since  1.0
  */
 class Cloudflare {
 
@@ -57,12 +56,9 @@ class Cloudflare {
 	/**
 	 * Get a Cloudflare\Api instance & the zone_id corresponding to the domain
 	 *
-	 * @since 2.8.21 Get the zone ID from the options
-	 * @since 2.8.18 Add try/catch to prevent fatal error Uncaugh Exception
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
-	 * @return Object Cloudflare instance & zone_id if credentials are correct, WP_Error otherwise
+	 * @return Object Cloudflare instance & zone_id if credentials are correct, WP_Error otherwise.
 	 */
 	public function get_cloudflare_instance() {
 		$cf_email             = $this->options->get( 'cloudflare_email', null );
@@ -89,14 +85,13 @@ class Cloudflare {
 	/**
 	 * Validate Cloudflare input data.
 	 *
-	 * @since  3.5
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param string $cf_email   - Cloudflare email.
 	 * @param string $cf_api_key - Cloudflare API key.
 	 * @param string $cf_zone_id - Cloudflare zone ID.
 	 *
-	 * @return Object                    - true if credentials are ok, WP_Error otherwise.
+	 * @return \stdClass true if credentials are ok, WP_Error otherwise.
 	 */
 	public function is_api_keys_valid( $cf_email, $cf_api_key, $cf_zone_id ) {
 		if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) ) {
@@ -107,7 +102,7 @@ class Cloudflare {
 			return new \WP_Error(
 				'cloudflare_credentials_empty',
 				sprintf(
-				/* translators: %1$s = opening link; %2$s = closing link */
+					/* translators: %1$s = opening link; %2$s = closing link */
 					__( 'Cloudflare email and/or API key are not set. Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
 					// translators: Documentation exists in EN, FR; use localized URL if applicable.
 					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
@@ -211,12 +206,11 @@ class Cloudflare {
 	/**
 	 * Checks if CF has the $action_value set as a Page Rule.
 	 *
-	 * @since  3.4.2
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param String $action_value - cache_everything.
 	 *
-	 * @return mixed  Object|bool   - true / false if $action_value was found or not, WP_Error otherwise
+	 * @return mixed  Object|bool true / false if $action_value was found or not, WP_Error otherwise.
 	 */
 	public function has_page_rule( $action_value ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -247,11 +241,9 @@ class Cloudflare {
 	/**
 	 * Purge Cloudflare cache.
 	 *
-	 * @since 2.9 Now returns value
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
-	 * @return mixed Object|bool true if the purge is successful, WP_Error otherwise
+	 * @return mixed Object|bool true if the purge is successful, WP_Error otherwise.
 	 */
 	public function purge_cloudflare() {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -280,14 +272,13 @@ class Cloudflare {
 	/**
 	 * Purge Cloudflare Cache by URL
 	 *
-	 * @since  3.4.2
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param WP_Post $post       The post object.
 	 * @param array   $purge_urls URLs cache files to remove.
 	 * @param string  $lang       The post language.
 	 *
-	 * @return mixed Object|bool  true if the purge is successful, WP_Error otherwise
+	 * @return mixed Object|bool true if the purge is successful, WP_Error otherwise
 	 */
 	public function purge_by_url( $post, $purge_urls, $lang ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -317,12 +308,11 @@ class Cloudflare {
 	/**
 	 * Set the Browser Cache TTL in Cloudflare.
 	 *
-	 * @since 2.9 Now returns value
-	 * @since 2.8.16
+	 * @since 1.0
 	 *
 	 * @param string $mode Value for Cloudflare browser cache TTL.
 	 *
-	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise
+	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise.
 	 */
 	public function set_browser_cache_ttl( $mode ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -351,13 +341,11 @@ class Cloudflare {
 	/**
 	 * Set the Cloudflare Rocket Loader.
 	 *
-	 * @since 2.9 Now returns value
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
 	 * @param string $mode Value for Cloudflare Rocket Loader.
 	 *
-	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise
+	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise.
 	 */
 	public function set_rocket_loader( $mode ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -386,13 +374,11 @@ class Cloudflare {
 	/**
 	 * Set the Cloudflare Minification.
 	 *
-	 * @since 2.9 Now returns a value
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
 	 * @param string $mode Value for Cloudflare minification.
 	 *
-	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise
+	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise.
 	 */
 	public function set_minify( $mode ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -427,13 +413,11 @@ class Cloudflare {
 	/**
 	 * Set the Cloudflare Caching level.
 	 *
-	 * @since 2.9 Now returns a value
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
 	 * @param string $mode Value for Cloudflare caching level.
 	 *
-	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise
+	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise.
 	 */
 	public function set_cache_level( $mode ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -462,13 +446,11 @@ class Cloudflare {
 	/**
 	 * Set the Cloudflare Development mode.
 	 *
-	 * @since 2.9 Now returns a value
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
 	 * @param string $mode Value for Cloudflare development mode.
 	 *
-	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise
+	 * @return mixed Object|String Mode value if the update is successful, WP_Error otherwise.
 	 */
 	public function set_devmode( $mode ) {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -507,10 +489,9 @@ class Cloudflare {
 	/**
 	 * Get all the current Cloudflare settings for a given domain.
 	 *
-	 * @since 2.8.16 Update to Cloudflare API v4
-	 * @since 2.5
+	 * @since 1.0
 	 *
-	 * @return mixed bool|Array Array of Cloudflare settings, false if any error connection to Cloudflare
+	 * @return mixed bool|Array Array of Cloudflare settings, false if any error connection to Cloudflare.
 	 */
 	public function get_settings() {
 		if ( is_wp_error( $this->cloudflare_api_error ) ) {
@@ -568,12 +549,9 @@ class Cloudflare {
 	/**
 	 * Get Cloudflare IPs. No API validation needed, all exceptions returns the default CF IPs array.
 	 *
-	 * @since  2.8.21 Save IPs in a transient to prevent calling the API everytime
-	 * @since  2.8.16
+	 * @since 1.0
 	 *
-	 * @author Remy Perona
-	 *
-	 * @return Object Result of API request if successful, default CF IPs otherwise
+	 * @return Object Result of API request if successful, default CF IPs otherwise.
 	 */
 	public function get_cloudflare_ips() {
 		$cf_ips = get_transient( 'rocket_cloudflare_ips' );
@@ -610,10 +588,9 @@ class Cloudflare {
 	/**
 	 * Get default Cloudflare IPs.
 	 *
-	 * @since  3.5
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
-	 * @return Object Default Cloudflare connecting IPs.
+	 * @return \stdClass Default Cloudflare connecting IPs.
 	 */
 	private function get_default_ips() {
 		$cf_ips = (object) [

--- a/CloudflareSubscriber.php
+++ b/CloudflareSubscriber.php
@@ -9,7 +9,7 @@ use WP_Rocket\Admin\Options;
 /**
  * Cloudflare Subscriber
  *
- * @since  3.5
+ * @since  1.0
  * @author Remy Perona
  */
 class CloudflareSubscriber implements Subscriber_Interface {
@@ -31,7 +31,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Options instance.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 *
 	 * @var Options
@@ -54,7 +54,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Gets the subscribed events.
 	 *
-	 * @since 3.5
+	 * @since 1.0
 	 *
 	 * @return array subscribed events => callbacks.
 	 */
@@ -81,7 +81,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Sets the Varnish IP to localhost if Cloudflare is active
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Remy Perona
 	 *
 	 * @param string|array $varnish_ip Varnish IP.
@@ -105,7 +105,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Sets the Host header to the website domain if Cloudflare is active
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Remy Perona
 	 *
 	 * @param string $host the host header value.
@@ -123,7 +123,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Checks if we should filter the value for the Varnish purge
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Remy Perona
 	 *
 	 * @return bool
@@ -368,7 +368,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Save Cloudflare admin options
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 *
 	 * @param array $old_value An array of previous values for the settings.
@@ -514,7 +514,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Save Cloudflare old settings when the auto settings option is enabled.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 *
 	 * @param array $value     An array of previous values for the settings.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@ This module adds Cloudflare to [WP Rocket](https://wp-rocket.me) or any other pr
 - Cloudflare handler: to make it easier to interact with the API.
 - Subscriber: to wire to WP Rocket or any other product.
 
-It uses native WordPress functionality including [`wp_remote_get()`](https://developer.wordpress.org/reference/functions/wp_remote_get/) and [`wp_remote_request()`]() instead of directly using curl.

--- a/Tests/Integration/Factory.php
+++ b/Tests/Integration/Factory.php
@@ -92,7 +92,7 @@ class Factory {
 		$this->container['options']        = new Options_Data(
 			$this->container['options_api']->get( 'settings', [] )
 		);
-		$this->container['cloudflare_api'] = new APIClient( 'cloudflare/3.5' );
+		$this->container['cloudflare_api'] = new APIClient( 'cloudflare/1.0' );
 		$this->container['cloudflare']     = new Cloudflare( $this->container['options'], $this->container['cloudflare_api'] );
 
 		$this->container['cloudflare_subscriber'] = new CloudflareSubscriber(

--- a/Tests/Unit/APIClient/changeBrowserCacheTtl.php
+++ b/Tests/Unit/APIClient/changeBrowserCacheTtl.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_ChangeBrowserCacheTtl extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/changeCacheLevel.php
+++ b/Tests/Unit/APIClient/changeCacheLevel.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_ChangeCacheLevel extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/changeDevelopmentMode.php
+++ b/Tests/Unit/APIClient/changeDevelopmentMode.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_ChangeDevelopmentMode extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/changeMinify.php
+++ b/Tests/Unit/APIClient/changeMinify.php
@@ -18,7 +18,7 @@ class Test_ChangeMinify extends TestCase {
 	];
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/getIps.php
+++ b/Tests/Unit/APIClient/getIps.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_GetIps extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/getSettings.php
+++ b/Tests/Unit/APIClient/getSettings.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_GetSettings extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/purge.php
+++ b/Tests/Unit/APIClient/purge.php
@@ -13,7 +13,7 @@ use WPMedia\Cloudflare\AuthenticationException;
 class Test_Purge extends TestCase {
 
 	public function testShouldThrowErrorWhenInvalidCredentials() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 
 		$this->expectException( AuthenticationException::class );
 		$this->expectExceptionMessage( 'Authentication information must be provided' );

--- a/Tests/Unit/APIClient/setApiCredentials.php
+++ b/Tests/Unit/APIClient/setApiCredentials.php
@@ -12,7 +12,7 @@ use WPMedia\Cloudflare\APIClient;
 class Test_SetApiCredentials extends TestCase {
 
 	public function testShouldSetEmail() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 		$email = $this->get_reflective_property( 'email', $api );
 
 		$api->set_api_credentials( '', null, null );
@@ -23,7 +23,7 @@ class Test_SetApiCredentials extends TestCase {
 	}
 
 	public function testShouldSetApiKeyWhenGiven() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 		$api_key = $this->get_reflective_property( 'api_key', $api );
 
 		$api->set_api_credentials( null, '', null );
@@ -34,7 +34,7 @@ class Test_SetApiCredentials extends TestCase {
 	}
 
 	public function testShouldSetZoneId() {
-		$api = new APIClient( 'cloudflare/3.5' );
+		$api = new APIClient( 'cloudflare/1.0' );
 		$zone_id = $this->get_reflective_property( 'zone_id', $api );
 
 		$api->set_api_credentials( null, null, 'zone1' );

--- a/Tests/Unit/Cloudflare/TestCase.php
+++ b/Tests/Unit/Cloudflare/TestCase.php
@@ -11,7 +11,7 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 *
 	 * @param integer $do_cloudflare - Value to return for $options->get( 'do_cloudflare' ).
 	 * @param string  $email         - Value to return for $options->get( 'cloudflare_email' ).
@@ -40,7 +40,7 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 *
 	 * @param integer $do_cloudflare - Value to return for $options->get( 'do_cloudflare' ).
 	 * @param string  $email         - Value to return for $options->get( 'cloudflare_email' ).

--- a/Tests/Unit/CloudflareSubscriber/autoPurge.php
+++ b/Tests/Unit/CloudflareSubscriber/autoPurge.php
@@ -100,7 +100,7 @@ class Test_AutoPurge extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/CloudflareSubscriber/autoPurgeByUrl.php
+++ b/Tests/Unit/CloudflareSubscriber/autoPurgeByUrl.php
@@ -121,7 +121,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/CloudflareSubscriber/purgeCache.php
+++ b/Tests/Unit/CloudflareSubscriber/purgeCache.php
@@ -116,7 +116,7 @@ class Test_PurgeCache extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/CloudflareSubscriber/saveCloudflareOptions.php
+++ b/Tests/Unit/CloudflareSubscriber/saveCloudflareOptions.php
@@ -320,7 +320,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/CloudflareSubscriber/saveOldSettings.php
+++ b/Tests/Unit/CloudflareSubscriber/saveOldSettings.php
@@ -82,7 +82,7 @@ class Test_SaveOldSettings extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/CloudflareSubscriber/setRealIp.php
+++ b/Tests/Unit/CloudflareSubscriber/setRealIp.php
@@ -108,7 +108,7 @@ class Test_SetRealIp extends TestCase {
 	/**
 	 * Get the mocks required by Cloudflare’s constructor.
 	 *
-	 * @since  3.5
+	 * @since  1.0
 	 * @author Soponar Cristina
 	 * @access private
 	 *

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends WPMediaTestCase {
 	}
 
 	protected function getAPIMock() {
-		return Mockery::mock( 'WPMedia\Cloudflare\APIClient', [ 'cloudflare/3.5' ] )
+		return Mockery::mock( 'WPMedia\Cloudflare\APIClient', [ 'cloudflare/1.0' ] )
 		              ->makePartial()
 		              ->shouldAllowMockingProtectedMethods();
 	}


### PR DESCRIPTION
This is a new package and a complete refactor of the Rocket Cloudflare Add-on. This PR sets the initial version to 1.0, instead of using Rocket's 3.5.