### PR TITLE
Improve subscriber.

### DIFF
--- a/CloudflareSubscriber.php
+++ b/CloudflareSubscriber.php
@@ -10,12 +10,11 @@ use WP_Rocket\Admin\Options;
  * Cloudflare Subscriber
  *
  * @since  1.0
- * @author Remy Perona
  */
 class CloudflareSubscriber implements Subscriber_Interface {
 
 	/**
-	 * Cloudflare instance
+	 * Cloudflare instance.
 	 *
 	 * @var Cloudflare
 	 */
@@ -30,9 +29,6 @@ class CloudflareSubscriber implements Subscriber_Interface {
 
 	/**
 	 * Options instance.
-	 *
-	 * @since  1.0
-	 * @author Soponar Cristina
 	 *
 	 * @var Options
 	 */
@@ -79,10 +75,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Sets the Varnish IP to localhost if Cloudflare is active
+	 * Sets the Varnish IP to localhost if Cloudflare is active.
 	 *
-	 * @since  1.0
-	 * @author Remy Perona
+	 * @since 1.0
 	 *
 	 * @param string|array $varnish_ip Varnish IP.
 	 *
@@ -103,10 +98,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Sets the Host header to the website domain if Cloudflare is active
+	 * Sets the Host header to the website domain if Cloudflare is active.
 	 *
-	 * @since  1.0
-	 * @author Remy Perona
+	 * @since 1.0
 	 *
 	 * @param string $host the host header value.
 	 *
@@ -121,10 +115,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Checks if we should filter the value for the Varnish purge
+	 * Checks if we should filter the value for the Varnish purge.
 	 *
-	 * @since  1.0
-	 * @author Remy Perona
+	 * @since 1.0
 	 *
 	 * @return bool
 	 */
@@ -143,10 +136,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 
 
 	/**
-	 * Automatically set Cloudflare development mode value to off after 3 hours to reflect Cloudflare behaviour
+	 * Automatically set Cloudflare development mode value to off after 3 hours to reflect Cloudflare behaviour.
 	 *
-	 * @since  2.9
-	 * @author Remy Perona
+	 * @since 1.0
 	 */
 	public function deactivate_devmode() {
 		if ( ! $this->options->get( 'do_cloudflare' ) ) {
@@ -158,10 +150,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Purge Cloudflare cache automatically if Cache Everything is set as a Page Rule
+	 * Purge Cloudflare cache automatically if Cache Everything is set as a Page Rule.
 	 *
-	 * @since  3.4.2
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 */
 	public function auto_purge() {
 		if ( ! $this->options->get( 'do_cloudflare' ) || ! current_user_can( 'rocket_purge_cloudflare_cache' ) ) {
@@ -179,10 +170,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Purge Cloudflare cache URLs automatically if Cache Everything is set as a Page Rule
+	 * Purge Cloudflare cache URLs automatically if Cache Everything is set as a Page Rule.
 	 *
-	 * @since  3.4.2
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param WP_Post $post       The post object.
 	 * @param array   $purge_urls URLs cache files to remove.
@@ -213,9 +203,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Purge CloudFlare cache
+	 * Purge CloudFlare cache.
 	 *
-	 * @since 2.5
+	 * @since 1.0
 	 */
 	public function purge_cache_no_die() {
 		if ( ! $this->options->get( 'do_cloudflare' ) || ! current_user_can( 'rocket_purge_cloudflare_cache' ) ) {
@@ -242,9 +232,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Purge CloudFlare cache
+	 * Purge CloudFlare cache.
 	 *
-	 * @since 2.5
+	 * @since 1.0
 	 */
 	public function purge_cache() {
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'rocket_purge_cloudflare' ) ) {
@@ -256,10 +246,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Set Real IP from CloudFlare
+	 * Set Real IP from CloudFlare.
 	 *
-	 * @since  2.8.16 Uses CloudFlare API v4 to get CloudFlare IPs
-	 * @since  2.5.4
+	 * @since 1.0
 	 * @source cloudflare.php - https://wordpress.org/plugins/cloudflare/
 	 */
 	public function set_real_ip() {
@@ -290,10 +279,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * This notice is displayed after purging the CloudFlare cache
+	 * This notice is displayed after purging the CloudFlare cache.
 	 *
-	 * @since  2.9
-	 * @author Remy Perona
+	 * @since 1.0
 	 */
 	public function maybe_display_purge_notice() {
 		if ( ! $this->options->get( 'do_cloudflare' ) || ! current_user_can( 'rocket_purge_cloudflare_cache' ) ) {
@@ -317,15 +305,19 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * This notice is displayed after modifying the CloudFlare settings
+	 * This notice is displayed after modifying the CloudFlare settings.
 	 *
-	 * @since  2.9
-	 * @author Remy Perona
+	 * @since 1.0
 	 */
 	public function maybe_print_update_settings_notice() {
 		$screen = get_current_screen();
 
-		if ( ! $this->options->get( 'do_cloudflare' ) || ! current_user_can( 'rocket_manage_options' ) || 'settings_page_wprocket' !== $screen->id ) {
+		if (
+			! $this->options->get( 'do_cloudflare' )
+			||
+			! current_user_can( 'rocket_manage_options' )
+			|| 'settings_page_wprocket' !== $screen->id
+		) {
 			return;
 		}
 
@@ -347,7 +339,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 		}
 
 		if ( ! empty( $success ) ) {
-			\rocket_notice_html(
+			rocket_notice_html(
 				[
 					'message' => $success,
 				]
@@ -355,7 +347,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 		}
 
 		if ( ! empty( $errors ) ) {
-			\rocket_notice_html(
+			rocket_notice_html(
 				[
 					'status'  => 'error',
 					'message' => $errors,
@@ -366,10 +358,9 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Save Cloudflare admin options
+	 * Save Cloudflare admin options.
 	 *
-	 * @since  1.0
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param array $old_value An array of previous values for the settings.
 	 * @param array $value     An array of submitted values for the settings.
@@ -514,11 +505,12 @@ class CloudflareSubscriber implements Subscriber_Interface {
 	/**
 	 * Save Cloudflare old settings when the auto settings option is enabled.
 	 *
-	 * @since  1.0
-	 * @author Soponar Cristina
+	 * @since 1.0
 	 *
 	 * @param array $value     An array of previous values for the settings.
 	 * @param array $old_value An array of submitted values for the settings.
+	 *
+	 * @return array settings with old settings.
 	 */
 	public function save_cloudflare_old_settings( $value, $old_value ) {
 		if ( ! current_user_can( 'rocket_manage_options' ) || ! $this->options->get( 'do_cloudflare' ) ) {
@@ -526,9 +518,17 @@ class CloudflareSubscriber implements Subscriber_Interface {
 		}
 
 		// Save old CloudFlare settings.
-		if ( isset( $value['cloudflare_auto_settings'], $old_value ['cloudflare_auto_settings'] ) && $value['cloudflare_auto_settings'] !== $old_value ['cloudflare_auto_settings'] && 1 === $value['cloudflare_auto_settings'] ) {
+		if (
+			isset( $value['cloudflare_auto_settings'], $old_value ['cloudflare_auto_settings'] )
+			&&
+			$value['cloudflare_auto_settings'] !== $old_value ['cloudflare_auto_settings']
+			&&
+			1 === $value['cloudflare_auto_settings']
+		) {
 			$cf_settings                      = $this->cloudflare->get_settings();
-			$value['cloudflare_old_settings'] = ! is_wp_error( $cf_settings ) ? implode( ',', array_filter( $cf_settings ) ) : '';
+			$value['cloudflare_old_settings'] = ! is_wp_error( $cf_settings )
+				? implode( ',', array_filter( $cf_settings ) )
+				: '';
 		}
 
 		return $value;

--- a/Subscriber.php
+++ b/Subscriber.php
@@ -241,15 +241,17 @@ class Subscriber implements Subscriber_Interface {
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'rocket_purge_cloudflare' ) ) {
 			wp_nonce_ays( '' );
 		}
+
 		$this->purge_cache_no_die();
+
 		wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
-		defined( 'WPMEDIA_IS_TESTING' )	? wp_die() : exit;
+		defined( 'WPMEDIA_IS_TESTING' ) ? wp_die() : exit;
 	}
 
 	/**
 	 * Set Real IP from CloudFlare.
 	 *
-	 * @since 1.0
+	 * @since  1.0
 	 * @source cloudflare.php - https://wordpress.org/plugins/cloudflare/
 	 */
 	public function set_real_ip() {

--- a/Subscriber.php
+++ b/Subscriber.php
@@ -188,6 +188,7 @@ class Subscriber implements Subscriber_Interface {
 		if ( is_wp_error( $cf_cache_everything ) || ! $cf_cache_everything ) {
 			return;
 		}
+
 		// Add home URL and feeds URLs to Cloudflare clean cache URLs list.
 		$purge_urls[] = get_rocket_i18n_home_url( $lang );
 		$feed_urls    = [];
@@ -199,7 +200,7 @@ class Subscriber implements Subscriber_Interface {
 		$purge_urls = array_unique( array_merge( $purge_urls, $feed_urls ) );
 
 		// Purge CloudFlare.
-		$cf_purge = $this->cloudflare->purge_by_url( $post, $purge_urls, $lang );
+		$this->cloudflare->purge_by_url( $post, $purge_urls, $lang );
 	}
 
 	/**

--- a/Subscriber.php
+++ b/Subscriber.php
@@ -7,11 +7,11 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 
 /**
- * Cloudflare Subscriber
+ * Cloudflare Subscriber.
  *
  * @since  1.0
  */
-class CloudflareSubscriber implements Subscriber_Interface {
+class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Cloudflare instance.

--- a/Subscriber.php
+++ b/Subscriber.php
@@ -242,7 +242,7 @@ class Subscriber implements Subscriber_Interface {
 		}
 		$this->purge_cache_no_die();
 		wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
-		die();
+		defined( 'WPMEDIA_IS_TESTING' )	? wp_die() : exit;
 	}
 
 	/**

--- a/Tests/Integration/Factory.php
+++ b/Tests/Integration/Factory.php
@@ -7,7 +7,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Event_Manager;
 use WPMedia\Cloudflare\Cloudflare;
 use WPMedia\Cloudflare\APIClient;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\PHPUnit\TestCaseTrait;
 
 class Factory {
@@ -95,7 +95,7 @@ class Factory {
 		$this->container['cloudflare_api'] = new APIClient( 'cloudflare/1.0' );
 		$this->container['cloudflare']     = new Cloudflare( $this->container['options'], $this->container['cloudflare_api'] );
 
-		$this->container['cloudflare_subscriber'] = new CloudflareSubscriber(
+		$this->container['cloudflare_subscriber'] = new Subscriber(
 			$this->container['cloudflare'],
 			$this->container['options'],
 			$this->container['options_api']

--- a/Tests/Integration/Factory.php
+++ b/Tests/Integration/Factory.php
@@ -41,7 +41,7 @@ class Factory {
 	}
 
 	private function setUpApiCredentials() {
-		self::$api_credentials_config_file = 'cloudflare.php';
+		self::$api_credentials_config_file = dirname( __DIR__ ) . '/env/local/cloudflare.php';
 		self::$email                       = self::getApiCredential( 'ROCKET_CLOUDFLARE_EMAIL' );
 		self::$api_key                     = self::getApiCredential( 'ROCKET_CLOUDFLARE_API_KEY' );
 		self::$zone_id                     = self::getApiCredential( 'ROCKET_CLOUDFLARE_ZONE_ID' );
@@ -133,13 +133,12 @@ class Factory {
 			return '';
 		}
 
-		$config_file = dirname( __DIR__ ) . '/env/local/cloudflare.php';
-		if ( ! is_readable( $config_file ) ) {
+		if ( ! is_readable( self::$api_credentials_config_file ) ) {
 			return '';
 		}
 
 		// This file is local to the developer's machine and not stored in the repo.
-		require_once $config_file;
+		require_once self::$api_credentials_config_file;
 
 		return rocket_get_constant( $name, '' );
 	}

--- a/Tests/Integration/Subscriber/autoPurge.php
+++ b/Tests/Integration/Subscriber/autoPurge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WPMedia\Cloudflare\Tests\Integration\CloudflareSubscriber;
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
 
 use Brain\Monkey\Functions;
 use WPMedia\Cloudflare\Tests\Integration\TestCase;
@@ -9,7 +9,7 @@ use function WPMedia\Cloudflare\Tests\Integration\getFactory;
 /**
  * @covers WPMedia\Cloudflare\CloudflareSubscriber::auto_purge
  * @group  Cloudflare
- * @group  CloudflareSubscriber
+ * @group  Subscriber
  */
 class Test_AutoPurge extends TestCase {
 	private static $options;

--- a/Tests/Integration/Subscriber/autoPurgeByUrl.php
+++ b/Tests/Integration/Subscriber/autoPurgeByUrl.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\Cloudflare\Tests\Integration\TestCase;
+use function WPMedia\Cloudflare\Tests\Integration\getFactory;
+
+/**
+ * @covers WPMedia\Cloudflare\Subscriber::auto_purge_by_url
+ * @group  Cloudflare
+ * @group  Subscriber
+ */
+class Test_AutoPurgeByUrl extends TestCase {
+	private static $options;
+	private static $cf;
+	private static $post_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$cf      = getFactory()->getContainer( 'cloudflare' );
+		self::$options = getFactory()->getContainer( 'options' );
+		self::$post_id = $factory->post->create();
+	}
+
+	public function testShouldBailoutWhenCFAddonOff() {
+		$this->setOptions( [ 'do_cloudflare' => 0 ] );
+
+		Functions\expect( 'current_user_can' )->with( 'rocket_purge_cloudflare_cache' )->never();
+		Functions\expect( 'get_rocket_i18n_home_url' )->never();
+
+		do_action( 'after_rocket_clean_post', self::$post_id, [], 'en' );
+	}
+
+	public function testShouldBailoutWhenUserCantPurgeCF() {
+		$user = $this->factory->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user );
+
+		Functions\expect( 'get_rocket_i18n_home_url' )->never();
+
+		do_action( 'after_rocket_clean_post', self::$post_id, [], 'en' );
+	}
+
+	public function testShouldBailoutWhenNoPageRule() {
+		// Set the user who can purge Cloudflare.
+		$admin = get_role( 'administrator' );
+		$admin->add_cap( 'rocket_purge_cloudflare_cache' );
+		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user );
+		$this->assertTrue( current_user_can( 'rocket_purge_cloudflare_cache' ) );
+
+		// Why? Because our test site doesn't have page rules.
+		Functions\expect( 'get_rocket_i18n_home_url' )->never();
+
+		do_action( 'after_rocket_clean_post', self::$post_id, [], 'en' );
+	}
+
+	private function setOptions( $options ) {
+		update_option( 'wp_rocket_settings', $options );
+		self::$options->set_values( $options );
+	}
+}

--- a/Tests/Integration/Subscriber/deactivateDevMode.php
+++ b/Tests/Integration/Subscriber/deactivateDevMode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WPMedia\Cloudflare\Tests\Integration\CloudflareSubscriber;
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
 
 use WPMedia\Cloudflare\Tests\Integration\TestCase;
 use function WPMedia\Cloudflare\Tests\Integration\getFactory;
@@ -8,7 +8,7 @@ use function WPMedia\Cloudflare\Tests\Integration\getFactory;
 /**
  * @covers WPMedia\Cloudflare\CloudflareSubscriber::deactivate_devmode
  * @group  Cloudflare
- * @group  CloudflareSubscriber
+ * @group  Subscriber
  */
 class Test_DeactivateDevMode extends TestCase {
 	private static $options;

--- a/Tests/Integration/Subscriber/purgeCache.php
+++ b/Tests/Integration/Subscriber/purgeCache.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\Cloudflare\Tests\Integration\TestCase;
+use WPDieException;
+use function WPMedia\Cloudflare\Tests\Integration\getFactory;
+
+/**
+ * @covers WPMedia\Cloudflare\Subscriber::purge_cache
+ * @covers WPMedia\Cloudflare\Subscriber::purge_cache_no_die
+ * @group  Cloudflare
+ * @group  Subscriber
+ */
+class Test_PurgeCache extends TestCase {
+	private static $options;
+	private static $cf;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$cf      = getFactory()->getContainer( 'cloudflare' );
+		self::$options = getFactory()->getContainer( 'options' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		unset( $_GET['_wpnonce'] );
+		set_current_screen( 'settings_page_wprocket' );
+	}
+
+	public function testShouldWPNonceAysWhenNonceIsMissing() {
+		Functions\expect( 'wp_verify_nonce' )->never();
+		Functions\expect( 'sanitize_key' )->never();
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessage( 'The link you followed has expired.' );
+		do_action( 'admin_post_rocket_purge_cloudflare' );
+	}
+
+	public function testShouldWPNonceAysWhenNonceInvalid() {
+		$_GET['_wpnonce'] = 'invalid';
+
+		Functions\expect( 'current_user_can' )->never();
+		Functions\expect( 'wp_safe_redirect' )->never();
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessage( 'The link you followed has expired.' );
+		do_action( 'admin_post_rocket_purge_cloudflare' );
+	}
+
+	public function testShouldBailoutWhenCFAddonOff() {
+		$this->setNonce();
+		Functions\expect( 'wp_nonce_ays' )->never();
+
+		// Turn off cloudflare.
+		$this->setOptions( [ 'do_cloudflare' => 0 ] );
+
+		Functions\expect( 'current_user_can' )->with( 'rocket_purge_cloudflare_cache' )->never();
+
+		$this->setRedirect();
+
+		// Run it.
+		do_action( 'admin_post_rocket_purge_cloudflare' );
+
+		// Just to make sure the transient did not get set.
+		$user_id = get_current_user_id();
+		$this->assertFalse( get_transient( "{$user_id}_cloudflare_purge_result" ) );
+
+		$this->cleanUp();
+	}
+
+	public function testShouldBailoutWhenUserCantPurgeCF() {
+		$user_id = $this->factory->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user_id );
+		$this->assertFalse( current_user_can( 'rocket_purge_cloudflare' ) );
+
+		$this->setRedirect();
+		$this->setNonce();
+
+		// Run it.
+		do_action( 'admin_post_rocket_purge_cloudflare' );
+
+		// Just to make sure the transient did not get set.
+		$this->assertFalse( get_transient( "{$user_id}_cloudflare_purge_result" ) );
+
+		$this->cleanUp( $user_id );
+	}
+
+	public function testShouldPurgeWhenUserCanPurgeCF() {
+		// Set the user who can purge Cloudflare.
+		$admin = get_role( 'administrator' );
+		$admin->add_cap( 'rocket_purge_cloudflare_cache' );
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( current_user_can( 'rocket_purge_cloudflare_cache' ) );
+
+		// Set the nonce and redirect.
+		$this->setRedirect();
+		$this->setNonce();
+
+		// Run it.
+		do_action( 'admin_post_rocket_purge_cloudflare' );
+
+		// Check that the transient was set.
+		$this->assertSame(
+			[
+				'result'  => 'success',
+				'message' => '<strong>WP Rocket:</strong> Cloudflare cache successfully purged.',
+			],
+			get_transient( "{$user_id}_cloudflare_purge_result" )
+		);
+
+		$this->cleanUp( $user_id );
+	}
+
+	private function setNonce() {
+		$_REQUEST['_wp_http_referer'] = addslashes( 'http://example.com/wp-admin/options-general.php?page=wprocket#page_cloudflare' );
+		$_SERVER['REQUEST_URI']       = $_REQUEST['_wp_http_referer'];
+		$_GET['_wpnonce']             = wp_create_nonce( 'rocket_purge_cloudflare' );
+
+		// Just checking.
+		$this->assertEquals( 1, wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'rocket_purge_cloudflare' ) );
+		Functions\expect( 'wp_nonce_ays' )->never();
+	}
+
+	private function setRedirect() {
+		// Let's redirect anywhere.
+		add_filter( 'wp_redirect', '__return_empty_string' );
+
+		// Yes, we do expect wp_die() when running tests.
+		Functions\expect( 'wp_die' )->once()->andReturn();
+//		$this->expectException( WPDieException::class );
+	}
+
+	private function cleanUp( $user_id = 0 ) {
+		if ( 0 === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		remove_filter( 'wp_redirect', '__return_empty_string' );
+		unset( $_REQUEST['_wp_http_referer'], $_SERVER['REQUEST_URI'], $_GET['_wpnonce'] );
+		delete_transient( "{$user_id}_cloudflare_purge_result" );
+	}
+
+	private function setOptions( $options ) {
+		update_option( 'wp_rocket_settings', $options );
+		self::$options->set_values( $options );
+	}
+}

--- a/Tests/Integration/Subscriber/setVarnishLocalhost.php
+++ b/Tests/Integration/Subscriber/setVarnishLocalhost.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace WPMedia\Cloudflare\Tests\Integration\CloudflareSubscriber;
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
 
 use WPMedia\Cloudflare\Tests\Integration\TestCase;
 
 /**
  * @covers WP_Rocket\Subscriber\Addons\Cloudflare\CloudflareSubscriber::set_varnish_localhost
  * @group  Cloudflare
- * @group  CloudflareSubscriber
+ * @group  Subscriber
  */
 class Test_SetVarnishLocalhost extends TestCase {
 

--- a/Tests/Integration/Subscriber/setVarnishPurgeRequestHost.php
+++ b/Tests/Integration/Subscriber/setVarnishPurgeRequestHost.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WPMedia\Cloudflare\Tests\Integration\CloudflareSubscriber;
+namespace WPMedia\Cloudflare\Tests\Integration\Subscriber;
 
 use WPMedia\Cloudflare\Tests\Integration\TestCase;
 use function WPMedia\Cloudflare\Tests\Integration\getFactory;
@@ -8,7 +8,7 @@ use function WPMedia\Cloudflare\Tests\Integration\getFactory;
 /**
  * @covers WPMedia\Cloudflare\CloudflareSubscriber::set_varnish_purge_request_host
  * @group  Cloudflare
- * @group  CloudflareSubscriber
+ * @group  Subscriber
  */
 class Test_SetVarnishPurgeRequestHost extends TestCase {
 

--- a/Tests/Integration/bootstrap.php
+++ b/Tests/Integration/bootstrap.php
@@ -2,6 +2,8 @@
 
 namespace WPMedia\Cloudflare\Tests\Integration;
 
+define( 'WPMEDIA_IS_TESTING', true );
+
 tests_add_filter(
 	'muplugins_loaded',
 	function() {

--- a/Tests/Unit/CloudflareSubscriber/autoPurge.php
+++ b/Tests/Unit/CloudflareSubscriber/autoPurge.php
@@ -5,7 +5,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 use WP_Error;
 
@@ -26,7 +26,7 @@ class Test_AutoPurge extends TestCase {
 		$cloudflare->shouldNotReceive( 'has_page_rule' );
 		$cloudflare->shouldNotReceive( 'purge_cloudflare' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
 
@@ -41,7 +41,7 @@ class Test_AutoPurge extends TestCase {
 		$cloudflare->shouldNotReceive( 'has_page_rule' );
 		$cloudflare->shouldNotReceive( 'purge_cloudflare' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
 
@@ -57,7 +57,7 @@ class Test_AutoPurge extends TestCase {
 		$cloudflare->shouldReceive( 'has_page_rule' )->andReturn( $wp_error );
 		$cloudflare->shouldNotReceive( 'purge_cloudflare' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
 
@@ -76,7 +76,7 @@ class Test_AutoPurge extends TestCase {
 		$cloudflare->shouldReceive( 'has_page_rule' )->andReturn( true );
 		$cloudflare->shouldReceive( 'purge_cloudflare' )->andReturn( $wp_error );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
 
@@ -93,7 +93,7 @@ class Test_AutoPurge extends TestCase {
 		$cloudflare->shouldReceive( 'has_page_rule' )->andReturn( true );
 		$cloudflare->shouldReceive( 'purge_cloudflare' )->andReturn( true );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
 

--- a/Tests/Unit/CloudflareSubscriber/autoPurgeByUrl.php
+++ b/Tests/Unit/CloudflareSubscriber/autoPurgeByUrl.php
@@ -5,7 +5,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 use WP_Error;
 
@@ -26,7 +26,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 		$cloudflare->shouldNotReceive( 'has_page_rule' );
 		$cloudflare->shouldNotReceive( 'purge_by_url' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
 	}
@@ -42,7 +42,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 		$cloudflare->shouldNotReceive( 'has_page_rule' );
 		$cloudflare->shouldNotReceive( 'purge_by_url' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
 	}
@@ -60,7 +60,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 		           ->andReturn( $wp_error );
 		$cloudflare->shouldNotReceive( 'purge_by_url' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
 	}
 
@@ -88,7 +88,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 		           ], '' )
 		           ->andReturn( $wp_error );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
 	}
 
@@ -114,7 +114,7 @@ class Test_AutoPurgeByUrl extends TestCase {
 		           ], '' )
 		           ->andReturn( true );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
 	}
 

--- a/Tests/Unit/CloudflareSubscriber/getSubscribedEvents.php
+++ b/Tests/Unit/CloudflareSubscriber/getSubscribedEvents.php
@@ -3,7 +3,7 @@
 namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 
 /**
  * @covers WPMedia\Cloudflare\CloudflareSubscriber::get_subscribed_events
@@ -29,6 +29,6 @@ class Test_GetSubscribedEvents extends TestCase {
 			],
 		];
 
-		$this->assertSame( $events, CloudflareSubscriber::get_subscribed_events() );
+		$this->assertSame( $events, Subscriber::get_subscribed_events() );
 	}
 }

--- a/Tests/Unit/CloudflareSubscriber/purgeCache.php
+++ b/Tests/Unit/CloudflareSubscriber/purgeCache.php
@@ -4,7 +4,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class Test_PurgeCache extends TestCase {
 		Functions\when( 'wp_verify_nonce' )->justReturn( true );
 		Functions\when( 'sanitize_key' )->justReturn( '' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->purge_cache_no_die();
 	}
 
@@ -45,7 +45,7 @@ class Test_PurgeCache extends TestCase {
 		Functions\when( 'sanitize_key' )->justReturn( '' );
 		Functions\when( 'current_user_can' )->justReturn( false );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->purge_cache_no_die();
 	}
 
@@ -79,7 +79,7 @@ class Test_PurgeCache extends TestCase {
 			->once()
 			->with('1_cloudflare_purge_result', $cf_purge_result );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$cloudflare_subscriber->purge_cache_no_die();
 	}
@@ -108,7 +108,7 @@ class Test_PurgeCache extends TestCase {
 			->once()
 			->with('1_cloudflare_purge_result', $cf_purge_result );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$cloudflare_subscriber->purge_cache_no_die();
 	}

--- a/Tests/Unit/CloudflareSubscriber/saveCloudflareOptions.php
+++ b/Tests/Unit/CloudflareSubscriber/saveCloudflareOptions.php
@@ -5,7 +5,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 use WP_Error;
 
@@ -27,7 +27,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		$cloudflare = Mockery::mock( Cloudflare::class );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [ 'do_cloudflare' => 1 ];
 		$value     = [ 'do_cloudflare' => 0 ];
@@ -45,7 +45,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		$cloudflare = Mockery::mock( Cloudflare::class );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [ 'do_cloudflare' => 1 ];
 		$value     = [ 'do_cloudflare' => 1 ];
@@ -72,7 +72,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 		Functions\expect( 'set_transient' )->once();
 		Functions\when( 'is_wp_error' )->justReturn( true );
 		Functions\expect( 'add_settings_error' )->once();
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'      => 1,
@@ -104,7 +104,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 		Functions\expect( 'set_transient' )->once();
 		Functions\when( 'is_wp_error' )->justReturn( false );
 		Functions\expect( 'add_settings_error' )->never();
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'      => 1,
@@ -148,7 +148,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'      => 1,
@@ -184,7 +184,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'      => 1,
@@ -243,7 +243,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'            => 1,
@@ -301,7 +301,7 @@ class Tes_SaveCloudflareOptions extends TestCase {
 
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'            => 1,

--- a/Tests/Unit/CloudflareSubscriber/saveOldSettings.php
+++ b/Tests/Unit/CloudflareSubscriber/saveOldSettings.php
@@ -5,7 +5,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 
 /**
@@ -26,7 +26,7 @@ class Test_SaveOldSettings extends TestCase {
 		$cloudflare = Mockery::mock( Cloudflare::class );
 		$cloudflare->shouldNotReceive( 'get_settings' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'            => 1,
@@ -61,7 +61,7 @@ class Test_SaveOldSettings extends TestCase {
 		];
 		$cloudflare->shouldReceive( 'get_settings' )->andReturn( $cf_settings_array );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$old_value = [
 			'do_cloudflare'            => 1,

--- a/Tests/Unit/CloudflareSubscriber/setRealIp.php
+++ b/Tests/Unit/CloudflareSubscriber/setRealIp.php
@@ -5,7 +5,7 @@ namespace WPMedia\Cloudflare\Tests\Unit\CloudflareSubscriber;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\CloudflareSubscriber;
+use WPMedia\Cloudflare\Subscriber;
 use WPMedia\Cloudflare\Tests\Unit\TestCase;
 
 /**
@@ -24,7 +24,7 @@ class Test_SetRealIp extends TestCase {
 		$cloudflare = Mockery::mock( Cloudflare::class );
 		$cloudflare->shouldNotReceive( 'get_cloudflare_ips' );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 
 		$cloudflare_subscriber->set_real_ip();
 	}
@@ -45,7 +45,7 @@ class Test_SetRealIp extends TestCase {
 		Functions\when( 'rocket_ipv6_in_range' )->justReturn( false );
 		Functions\when( 'rocket_ipv4_in_range' )->justReturn( false );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->set_real_ip();
 
 		$this->assertNotEquals(
@@ -70,7 +70,7 @@ class Test_SetRealIp extends TestCase {
 		Functions\when( 'rocket_ipv6_in_range' )->justReturn( false );
 		Functions\when( 'rocket_ipv4_in_range' )->justReturn( true );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->set_real_ip();
 
 		$this->assertSame(
@@ -95,7 +95,7 @@ class Test_SetRealIp extends TestCase {
 		Functions\when( 'rocket_ipv6_in_range' )->justReturn( true );
 		Functions\when( 'rocket_ipv4_in_range' )->justReturn( false );
 
-		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
+		$cloudflare_subscriber = new Subscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->set_real_ip();
 
 		$this->assertSame(

--- a/composer.lock
+++ b/composer.lock
@@ -1878,16 +1878,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -1899,7 +1899,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -1932,7 +1932,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1976,16 +1976,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
                 "shasum": ""
             },
             "require": {
@@ -2020,7 +2020,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24T13:36:37+00:00"
+            "time": "2020-02-14T12:15:55+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2161,12 +2161,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-media/phpunit.git",
-                "reference": "766715679911ff453d5686c6d7befc395a9f452a"
+                "reference": "36a126eb75bcf758f0a17d92a75b4dbdebe0de55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/766715679911ff453d5686c6d7befc395a9f452a",
-                "reference": "766715679911ff453d5686c6d7befc395a9f452a",
+                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/36a126eb75bcf758f0a17d92a75b4dbdebe0de55",
+                "reference": "36a126eb75bcf758f0a17d92a75b4dbdebe0de55",
                 "shasum": ""
             },
             "require": {
@@ -2197,7 +2197,7 @@
             ],
             "description": "PHPUnit extender for bootstrapping unit and WordPress integration test suites.",
             "homepage": "https://github.com/wp-media/phpunit",
-            "time": "2020-02-12T20:10:29+00:00"
+            "time": "2020-02-14T03:13:42+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
- Renames to `Subscriber` as `CloudflareSubscriber` is redundant. The namespace tells us it belongs to `Cloudflare`.
- Cleans up the documentation.
- Adds integration tests for `auto_purge_by_url`.
- Adds integration tests for `purge_cache`.