### PR TITLE
Fixes Issue #15: Bails out if "do_cloudflare" is not set.

### DIFF
--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -49,8 +49,6 @@ class Cloudflare {
 			return;
 		}
 
-		$this->cloudflare_api_error = null;
-
 		// Update api_error with WP_Error if credentials are not valid.
 		// Update API with Cloudflare instance with correct auth data.
 		$this->get_cloudflare_instance();

--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -43,13 +43,14 @@ class Cloudflare {
 	 */
 	public function __construct( Options_Data $options, APIClient $api ) {
 		$this->options = $options;
+		$this->api     = $api;
 
 		if ( ! $this->options->get( 'do_cloudflare' ) ) {
 			return;
 		}
 
 		$this->cloudflare_api_error = null;
-		$this->api                  = $api;
+
 		// Update api_error with WP_Error if credentials are not valid.
 		// Update API with Cloudflare instance with correct auth data.
 		$this->get_cloudflare_instance();
@@ -104,7 +105,7 @@ class Cloudflare {
 			return new WP_Error(
 				'cloudflare_credentials_empty',
 				sprintf(
-					/* translators: %1$s = opening link; %2$s = closing link */
+				/* translators: %1$s = opening link; %2$s = closing link */
 					__( 'Cloudflare email and/or API key are not set. Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
 					// translators: Documentation exists in EN, FR; use localized URL if applicable.
 					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
@@ -118,11 +119,11 @@ class Cloudflare {
 
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
-				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-				// translators: Documentation exists in EN, FR; use localized URL if applicable.
-				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-				'</a>'
-			);
+					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+					// translators: Documentation exists in EN, FR; use localized URL if applicable.
+					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+					'</a>'
+				);
 
 			return new WP_Error( 'cloudflare_no_zone_id', $msg );
 		}
@@ -139,11 +140,11 @@ class Cloudflare {
 
 						$msg .= ' ' . sprintf(
 							/* translators: %1$s = opening link; %2$s = closing link */
-							__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-							// translators: Documentation exists in EN, FR; use localized URL if applicable.
-							'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-							'</a>'
-						);
+								__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+								// translators: Documentation exists in EN, FR; use localized URL if applicable.
+								'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+								'</a>'
+							);
 
 						return new WP_Error( 'cloudflare_invalid_auth', $msg );
 					}
@@ -153,11 +154,11 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-					// translators: Documentation exists in EN, FR; use localized URL if applicable.
-					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-					'</a>'
-				);
+						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+						// translators: Documentation exists in EN, FR; use localized URL if applicable.
+						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+						'</a>'
+					);
 
 				return new WP_Error( 'cloudflare_invalid_auth', $msg );
 			}
@@ -181,25 +182,25 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-					// translators: Documentation exists in EN, FR; use localized URL if applicable.
-					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-					'</a>'
-				);
+						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+						// translators: Documentation exists in EN, FR; use localized URL if applicable.
+						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+						'</a>'
+					);
 
 				return new WP_Error( 'cloudflare_wrong_zone_id', $msg );
 			}
 
 			return true;
 		} catch ( Exception $e ) {
-			$msg  = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
+			$msg = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
-				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-				// translators: Documentation exists in EN, FR; use localized URL if applicable.
-				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-				'</a>'
-			);
+					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+					// translators: Documentation exists in EN, FR; use localized URL if applicable.
+					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+					'</a>'
+				);
 
 			return new WP_Error( 'cloudflare_invalid_auth', $msg );
 		}

--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -117,11 +117,11 @@ class Cloudflare {
 
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
-					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-					// translators: Documentation exists in EN, FR; use localized URL if applicable.
-					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-					'</a>'
-				);
+				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+				// translators: Documentation exists in EN, FR; use localized URL if applicable.
+				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+				'</a>'
+			);
 
 			return new WP_Error( 'cloudflare_no_zone_id', $msg );
 		}
@@ -138,11 +138,11 @@ class Cloudflare {
 
 						$msg .= ' ' . sprintf(
 							/* translators: %1$s = opening link; %2$s = closing link */
-								__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-								// translators: Documentation exists in EN, FR; use localized URL if applicable.
-								'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-								'</a>'
-							);
+							__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+							// translators: Documentation exists in EN, FR; use localized URL if applicable.
+							'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+							'</a>'
+						);
 
 						return new WP_Error( 'cloudflare_invalid_auth', $msg );
 					}
@@ -152,11 +152,11 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-						// translators: Documentation exists in EN, FR; use localized URL if applicable.
-						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-						'</a>'
-					);
+					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+					// translators: Documentation exists in EN, FR; use localized URL if applicable.
+					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+					'</a>'
+				);
 
 				return new WP_Error( 'cloudflare_invalid_auth', $msg );
 			}
@@ -180,25 +180,25 @@ class Cloudflare {
 
 				$msg .= ' ' . sprintf(
 					/* translators: %1$s = opening link; %2$s = closing link */
-						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-						// translators: Documentation exists in EN, FR; use localized URL if applicable.
-						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-						'</a>'
-					);
+					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+					// translators: Documentation exists in EN, FR; use localized URL if applicable.
+					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+					'</a>'
+				);
 
 				return new WP_Error( 'cloudflare_wrong_zone_id', $msg );
 			}
 
 			return true;
 		} catch ( Exception $e ) {
-			$msg = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
+			$msg  = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
 			$msg .= ' ' . sprintf(
 				/* translators: %1$s = opening link; %2$s = closing link */
-					__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
-					// translators: Documentation exists in EN, FR; use localized URL if applicable.
-					'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
-					'</a>'
-				);
+				__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+				// translators: Documentation exists in EN, FR; use localized URL if applicable.
+				'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+				'</a>'
+			);
 
 			return new WP_Error( 'cloudflare_invalid_auth', $msg );
 		}

--- a/Subscriber.php
+++ b/Subscriber.php
@@ -255,6 +255,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @source cloudflare.php - https://wordpress.org/plugins/cloudflare/
 	 */
 	public function set_real_ip() {
+		if ( ! $this->options->get( 'do_cloudflare' ) ) {
+			return false;
+		}
+
 		// only run this logic if the REMOTE_ADDR is populated, to avoid causing notices in CLI mode.
 		if ( ! isset( $_SERVER['HTTP_CF_CONNECTING_IP'], $_SERVER['REMOTE_ADDR'] ) ) {
 			return;


### PR DESCRIPTION
- If `'do_cloudflare'` is not on, bail out of `Subscriber->set_real_ip()`.
- Sets `Cloudflare::$api` property even if `'do_cloudflare'` is not set. Why? In the event that the option is turned on _after_ CF is instantiated.

Closes #15 