### PR TITLE
[WIP] Adds cURL error handling to the Cloudflare::errors array.

### DIFF
--- a/APIClient.php
+++ b/APIClient.php
@@ -313,12 +313,14 @@ class APIClient {
 			$response->success = false;
 		}
 
-		if ( true !== $response->success ) {
-			$response->error       = $error;
-			$response->http_code   = $http_code;
-			$response->method      = $method;
-			$response->information = $information;
+		if ( true === $response->success ) {
+			return $response;
 		}
+
+		$response->error       = $error;
+		$response->http_code   = $http_code;
+		$response->method      = $method;
+		$response->information = $information;
 
 		return $response;
 	}

--- a/APIClient.php
+++ b/APIClient.php
@@ -374,10 +374,10 @@ class APIClient {
 		);
 
 		$packet = [
-			curl_exec( $ch ), // $http_result
-			curl_error( $ch ), // $error
-			curl_getinfo( $ch ), // $information
-			curl_getinfo( $ch, CURLINFO_HTTP_CODE ), // $http_code
+			curl_exec( $ch ),
+			curl_error( $ch ),
+			curl_getinfo( $ch ),
+			curl_getinfo( $ch, CURLINFO_HTTP_CODE ),
 		];
 
 		curl_close( $ch );
@@ -458,6 +458,6 @@ class APIClient {
 	 * @return bool true when API credentials are needed; else false.
 	 */
 	private function are_credentials_needed( $url ) {
-		return ( substr( $url, - 4 ) !== '/ips' );
+		return ( substr( $url, -4 ) !== '/ips' );
 	}
 }

--- a/Tests/Integration/APIClient/getZones.php
+++ b/Tests/Integration/APIClient/getZones.php
@@ -2,6 +2,8 @@
 
 namespace WPMedia\Cloudflare\Tests\Integration\APIClient;
 
+use Mockery;
+use WPMedia\Cloudflare\APIClient;
 use WPMedia\Cloudflare\AuthenticationException;
 
 /**
@@ -36,5 +38,29 @@ class Test_GetZones extends TestCase {
 		$response = self::$api->get_zones();
 		$this->assertTrue( $response->success );
 		$this->assertSame( self::$zone_id, $response->result->id );
+	}
+
+	public function testShouldFailWhenNonhttpErrorExists() {
+		$api = Mockery::mock( APIClient::class, [ 'cloudflare/1.0' ] )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$api->set_api_credentials( self::$email, self::$api_key, self::$zone_id );
+		$api->shouldReceive( 'get_request_route' )
+		    ->once()
+			->with( 'zones/zone1234' )
+		    ->andReturn( 'https://example.invalid/zones/zone1234' );
+
+		$api->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$response = $api->get_zones();
+		$this->assertFalse( $response->success );
+		$this->assertCount( 1, $response->errors );
+
+		$expected = 'Could not resolve host: example.invalid';
+		$error = $response->errors[0];
+		$this->assertSame( 0, $error->code );
+		$this->assertSame( $expected, $error->message );
+		$this->assertSame( $expected, $response->error );
+		$this->assertSame( 0, $response->http_code );
+		$this->assertSame( 'https://example.invalid/zones/zone1234?', $response->information['url'] );
 	}
 }

--- a/Tests/Unit/APIClient/getZones.php
+++ b/Tests/Unit/APIClient/getZones.php
@@ -22,11 +22,11 @@ class Test_GetZones extends TestCase {
 
 	public function testShouldFailWhenInvalid() {
 		$api = $this->getAPIMock();
-		$api->shouldReceive( 'request' )
+		$api->shouldReceive( 'do_remote_request' )
 		    ->once()
 		    ->with( 'zones/invalid', [], 'get' )
 		    ->andReturnUsing( function() {
-			    return (object) [
+			    $http_result = json_encode( (object) [
 				    'result'  => [],
 				    'success' => false,
 				    'errors'  => [
@@ -35,7 +35,10 @@ class Test_GetZones extends TestCase {
 						    'message' => 'Could not route to /zones/invalid, perhaps your object identifier is invalid?',
 					    ],
 				    ],
-			    ];
+			    ]
+			    );
+
+			    return [ $http_result, '', null, 200 ];
 		    } );
 
 		$api->set_api_credentials( 'test@example.com', 'API_KEY', 'invalid' );
@@ -47,19 +50,44 @@ class Test_GetZones extends TestCase {
 		$this->assertSame( 'Could not route to /zones/invalid, perhaps your object identifier is invalid?', $zone_error->message );
 	}
 
+	public function testShouldFailWhenCurlErrorExists() {
+		$curl_error_message = 'cURL error 60: SSL certificate problem: self signed certificate';
+
+		$api = $this->getAPIMock();
+		$api->shouldReceive( 'do_remote_request' )
+		    ->once()
+		    ->with( 'zones/zone1234', [], 'get' )
+		    ->andReturnUsing( function() use ( $curl_error_message ) {
+			    return [ '', $curl_error_message, null, '' ];
+		    } );
+
+		$api->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );
+
+		$response = $api->get_zones();
+		$this->assertFalse( $response->success );
+		$this->assertCount( 1, $response->errors );
+		$curl_error = $response->errors[0];
+		$this->assertSame( '', $curl_error->code );
+		$this->assertSame( $curl_error_message, $curl_error->message );
+		$this->assertSame( $curl_error_message, $response->error );
+		$this->assertSame( '', $response->http_code );
+	}
+
 	public function testShouldSucceedWhenZoneExists() {
 		$api = $this->getAPIMock();
-		$api->shouldReceive( 'request' )
+		$api->shouldReceive( 'do_remote_request' )
 		    ->once()
 		    ->with( 'zones/zone1234', [], 'get' )
 		    ->andReturnUsing( function() {
-			    return (object) [
+			    $http_result = json_encode( (object) [
 				    'result'  => (object) [
 					    'id' => 'zone1234',
 				    ],
 				    'success' => true,
 				    'errors'  => [],
-			    ];
+			    ] );
+
+			    return [ $http_result, '', null, 200 ];
 		    } );
 
 		$api->set_api_credentials( 'test@example.com', 'API_KEY', 'zone1234' );


### PR DESCRIPTION
This PR adds cURL error handling into the returned response packet. 

The original version handles error responses from Cloudflare, but did not handle cURL errors. As a result, it threw the following notice:

```
PHP Notice: Undefined property: stdClass::$error in wp-rocket\inc\Addon\Cloudflare\Cloudflare.php on line 131
```

This PR checks for a cURL error. When it's present, it automatically formats to a `stdClass` data type and then adds it to the response errors array.

QA

- [x] Automated tests
- [x] Passes automated code review
- [ ] Live tested

Ref: [Issue 2369](https://github.com/wp-media/wp-rocket/issues/2369) on Rocket.